### PR TITLE
Fix string filter in query extensions

### DIFF
--- a/LifelogBb/Utilities/ControllerQueryExtensions.cs
+++ b/LifelogBb/Utilities/ControllerQueryExtensions.cs
@@ -38,9 +38,9 @@ namespace LifelogBb.Utilities
             var prop = query.ElementType.GetProperty(field);
             if (prop == null) { return query; }
 
-            if (prop.GetType() != typeof(string)) { return query; }
+            if (prop.PropertyType != typeof(string)) { return query; }
 
-            return query.Where(e => EF.Property<string>(e, field).Contains(""));
+            return query.Where(e => EF.Property<string>(e, field).Contains(searchString));
         }
 
         public static IQueryable<T> FilterByDoubleProps<T>(this IQueryable<T> query, string field, string searchString, double range)


### PR DESCRIPTION
## Summary
- fix `FilterByStringProps` to properly filter on the provided search string

## Testing
- `dotnet build LifelogBb/LifelogBb.csproj -clp:ErrorsOnly` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684fa8a93b40832ca5b5c8bfb492904e