### PR TITLE
Potential fix for code scanning alert no. 48: Missing cross-site request forgery token validation

### DIFF
--- a/LifelogBb/ApiControllers/AuthenticationController.cs
+++ b/LifelogBb/ApiControllers/AuthenticationController.cs
@@ -20,6 +20,7 @@ namespace LifelogBb.ApiControllers
 
         [HttpPost]
         [AllowAnonymous]
+        [ValidateAntiForgeryToken]
         public IActionResult Authenticate([FromBody] LoginModel loginModel)
         {
             if (loginModel == null)


### PR DESCRIPTION
Potential fix for [https://github.com/spech66/lifelogbb/security/code-scanning/48](https://github.com/spech66/lifelogbb/security/code-scanning/48)

In general, to fix missing CSRF protection in ASP.NET Core, you enable the antiforgery system and require that state‑changing or authentication POST endpoints validate an antiforgery token, typically through an attribute like `[ValidateAntiForgeryToken]` on MVC actions or a global filter. The client must send the token (usually from a hidden form field or header), and the server validates it, rejecting requests without a valid token.

For this specific controller/action, the least invasive change that satisfies the CodeQL rule is to add an antiforgery‑validation attribute to the `Authenticate` method, without changing its existing logic or return values. Since this is an `[ApiController]` and we are constrained to only editing the shown snippet, the most straightforward fix is to apply a filter attribute that requires antiforgery validation on this action. In ASP.NET Core, this can be done with `[ValidateAntiForgeryToken]` if the antiforgery system is configured in the app. Because we cannot modify other files, we will just add the attribute here; the rest of the configuration is assumed to exist elsewhere in the project. We also must add the necessary using directive (`Microsoft.AspNetCore.Mvc` already imported) or reuse existing imports; `[ValidateAntiForgeryToken]` is in `Microsoft.AspNetCore.Mvc`, which is already present, so no new imports are needed. Concretely, in `LifelogBb/ApiControllers/AuthenticationController.cs`, directly above `public IActionResult Authenticate(...)`, we will add `[ValidateAntiForgeryToken]` so that every POST to `/api/authentication` must include a valid anti‑forgery token.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
