### PR TITLE
Add a long lived MCP token for MCP client connections

### DIFF
--- a/LifelogBb/Migrations/20260802141344_McpToken.Designer.cs
+++ b/LifelogBb/Migrations/20260802141344_McpToken.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LifelogBb.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LifelogBb.Migrations
 {
     [DbContext(typeof(LifelogBbContext))]
-    partial class LifelogBbContextModelSnapshot : ModelSnapshot
+    [Migration("20260802141344_McpToken")]
+    partial class McpToken
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/LifelogBb/Migrations/20260802141344_McpToken.cs
+++ b/LifelogBb/Migrations/20260802141344_McpToken.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LifelogBb.Migrations
+{
+    /// <inheritdoc />
+    public partial class McpToken : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "McpToken",
+                table: "Configs",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "McpToken",
+                table: "Configs");
+        }
+    }
+}

--- a/LifelogBb/Models/Entities/Config.cs
+++ b/LifelogBb/Models/Entities/Config.cs
@@ -54,6 +54,12 @@ namespace LifelogBb.Models.Entities
 
         public int ChatMaxToolRoundtrips { get; set; } = 10;
 
+        /// <summary>
+        /// Long lived token for MCP clients, sent as "Authorization: Bearer &lt;token&gt;".
+        /// Empty disables token authentication and only allows short lived JWT tokens.
+        /// </summary>
+        public string McpToken { get; set; } = "";
+
         public Config()
         {
             // Default constructor

--- a/LifelogBb/Models/Home/EditConfigViewModel.cs
+++ b/LifelogBb/Models/Home/EditConfigViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using LifelogBb.Models.Entities;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 using System.ComponentModel.DataAnnotations;
 
 namespace LifelogBb.Models.Home
@@ -54,6 +55,9 @@ namespace LifelogBb.Models.Home
 
         public string ChatEndpoint { get; set; } = "https://api.openai.com/v1/chat/completions";
 
+        // Optional. Leaving it blank keeps the stored key, so the implicit "required" validation
+        // for non nullable strings must not reject an empty value.
+        [ValidateNever]
         public string ChatApiKey { get; set; } = "";
 
         public bool HasChatApiKey { get; set; }
@@ -64,6 +68,11 @@ namespace LifelogBb.Models.Home
 
         [Range(1, 50)]
         public int ChatMaxToolRoundtrips { get; set; } = 10;
+
+        // Optional. An empty value disables token authentication for the MCP server.
+        [ValidateNever]
+        [Display(Name = "MCP Token")]
+        public string McpToken { get; set; } = "";
 
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {

--- a/LifelogBb/Models/LifelogBbContext.cs
+++ b/LifelogBb/Models/LifelogBbContext.cs
@@ -78,6 +78,7 @@ namespace LifelogBb.Models
             modelBuilder.Entity<Config>().Property(b => b.ChatModel).HasDefaultValue("gpt-4o");
             modelBuilder.Entity<Config>().Property(b => b.ChatSystemPrompt).HasDefaultValue("You are a helpful life-tracking assistant for LifelogBB. You can query the user's data (weights, journals, todos, goals, habits, quotes, strength trainings, endurance trainings) using the available tools. Summarize and analyze the data to help the user understand their progress and habits.");
             modelBuilder.Entity<Config>().Property(b => b.ChatMaxToolRoundtrips).HasDefaultValue(10);
+            modelBuilder.Entity<Config>().Property(b => b.McpToken).HasDefaultValue("");
 
             modelBuilder.Entity<ChatSession>()
                 .HasMany(s => s.Messages)

--- a/LifelogBb/Program.cs
+++ b/LifelogBb/Program.cs
@@ -4,6 +4,7 @@ using LifelogBb.DTOs;
 using LifelogBb.Interfaces;
 using LifelogBb.Models;
 using LifelogBb.Utilities;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.HttpOverrides;
@@ -161,11 +162,19 @@ namespace LifelogBb
                     IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(config["Authentication:JwtToken:SigningKey"]))
                 };
             })
+            .AddScheme<AuthenticationSchemeOptions, McpTokenAuthenticationHandler>(
+                McpTokenDefaults.AuthenticationScheme, McpTokenDefaults.DisplayName, options => { })
             .AddMcp()
             .AddPolicyScheme("JWT_OR_COOKIE", "JWT_OR_COOKIE", options =>
             {
                 options.ForwardDefaultSelector = context =>
                 {
+                    // The MCP endpoint is only used by non interactive clients. Always use the MCP token
+                    // scheme so a missing or wrong token returns a plain 401 instead of a redirect to the
+                    // login page. The handler falls back to JWT if the value is not the configured token.
+                    if (context.Request.Path.StartsWithSegments("/mcp"))
+                        return McpTokenDefaults.AuthenticationScheme;
+
                     string authorization = context.Request.Headers[HeaderNames.Authorization];
                     if (!string.IsNullOrEmpty(authorization) && authorization.StartsWith("Bearer "))
                         return JwtBearerDefaults.AuthenticationScheme;

--- a/LifelogBb/Utilities/McpTokenAuthenticationHandler.cs
+++ b/LifelogBb/Utilities/McpTokenAuthenticationHandler.cs
@@ -1,0 +1,101 @@
+using LifelogBb.Models;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Encodings.Web;
+
+namespace LifelogBb.Utilities;
+
+/// <summary>
+/// Constants for the long lived MCP token authentication scheme.
+/// </summary>
+public static class McpTokenDefaults
+{
+    public const string AuthenticationScheme = "McpToken";
+
+    public const string DisplayName = "MCP static token";
+
+    /// <summary>
+    /// Well known placeholder that never authenticates, mirroring the FeedToken default.
+    /// </summary>
+    public const string DisabledPlaceholder = "ChangeMeInTheConfig";
+}
+
+/// <summary>
+/// Authenticates MCP clients with the long lived token from the app config
+/// (<see cref="Models.Entities.Config.McpToken"/>) sent as "Authorization: Bearer &lt;token&gt;".
+/// Falls back to the regular JWT bearer scheme so existing API tokens keep working on /mcp.
+/// </summary>
+public class McpTokenAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    private const string BearerPrefix = "Bearer ";
+
+    private readonly LifelogBbContext _context;
+
+    public McpTokenAuthenticationHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger,
+        UrlEncoder encoder, LifelogBbContext context)
+        : base(options, logger, encoder)
+    {
+        _context = context;
+    }
+
+    protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        string? authorization = Request.Headers[HeaderNames.Authorization];
+        if (string.IsNullOrWhiteSpace(authorization) || !authorization.StartsWith(BearerPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return AuthenticateResult.NoResult();
+        }
+
+        var presentedToken = authorization[BearerPrefix.Length..].Trim();
+        if (presentedToken.Length == 0)
+        {
+            return AuthenticateResult.NoResult();
+        }
+
+        // Read only. Config.GetConfig would insert and save a row as a side effect which must not
+        // happen while the request is still unauthenticated.
+        var configuredToken = await _context.Configs.AsNoTracking().Select(c => c.McpToken).FirstOrDefaultAsync();
+
+        if (IsEnabled(configuredToken) && FixedTimeEquals(configuredToken!, presentedToken))
+        {
+            var claims = new List<Claim>
+            {
+                new Claim(ClaimTypes.Name, "MCP client"),
+                new Claim(ClaimTypes.Role, "Administrator"),
+            };
+
+            // The authentication type has to be set or ClaimsIdentity.IsAuthenticated stays false.
+            var identity = new ClaimsIdentity(claims, Scheme.Name);
+            return AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(identity), Scheme.Name));
+        }
+
+        // Not the configured token (or token authentication is disabled), try the regular JWT flow.
+        return await Context.AuthenticateAsync(JwtBearerDefaults.AuthenticationScheme);
+    }
+
+    protected override Task HandleChallengeAsync(AuthenticationProperties properties)
+    {
+        // Never redirect to the cookie login page, MCP clients need a plain 401.
+        Response.StatusCode = StatusCodes.Status401Unauthorized;
+        Response.Headers[HeaderNames.WWWAuthenticate] = "Bearer";
+        return Task.CompletedTask;
+    }
+
+    protected override Task HandleForbiddenAsync(AuthenticationProperties properties)
+    {
+        Response.StatusCode = StatusCodes.Status403Forbidden;
+        return Task.CompletedTask;
+    }
+
+    private static bool IsEnabled(string? configuredToken) =>
+        !string.IsNullOrWhiteSpace(configuredToken) && configuredToken != McpTokenDefaults.DisabledPlaceholder;
+
+    private static bool FixedTimeEquals(string a, string b) =>
+        CryptographicOperations.FixedTimeEquals(Encoding.UTF8.GetBytes(a), Encoding.UTF8.GetBytes(b));
+}

--- a/LifelogBb/Views/Home/Config.cshtml
+++ b/LifelogBb/Views/Home/Config.cshtml
@@ -165,7 +165,13 @@
                     <div class="card-body">
                         <div class="alert alert-info" role="alert">
                             <h4 class="alert-title">MCP Server</h4>
-                            <div class="text-secondary">LifelogBB includes a built-in <strong>Model Context Protocol (MCP)</strong> server at <code>/mcp</code>. Connect AI assistants (e.g. Claude Desktop, GitHub Copilot, Cursor) by providing your instance URL and a JWT Bearer token obtained from <a href="/Swagger/" target="_blank">Swagger UI</a> via <code>/api/authentication/token</code>.</div>
+                            <div class="text-secondary">LifelogBB includes a built-in <strong>Model Context Protocol (MCP)</strong> server at <code>/mcp</code>. Connect AI assistants (e.g. Claude Desktop, GitHub Copilot, Cursor) by providing your instance URL and the MCP token below as an <code>Authorization: Bearer</code> header. Alternatively use a short lived JWT token obtained from <a href="/Swagger/" target="_blank">Swagger UI</a> via <code>POST /api/authentication</code>.</div>
+                        </div>
+                        <div class="form-group mb-3">
+                            <label asp-for="McpToken" class="control-label mb-1"></label>
+                            <input asp-for="McpToken" class="form-control form-control-lg" placeholder="Leave empty to disable token authentication" />
+                            <div class="form-hint">Long lived token for MCP clients. Sent as <code>Authorization: Bearer &lt;token&gt;</code>. It never expires and grants full access to your data, so use a long random value. Leave empty to allow only short lived JWT tokens.</div>
+                            <span asp-validation-for="McpToken" class="text-danger"></span>
                         </div>
                         <div class="form-group mb-3">
                             <label asp-for="ChatEndpoint" class="control-label mb-1"></label>

--- a/README.md
+++ b/README.md
@@ -209,7 +209,10 @@ WantedBy=multi-user.target
 
 LifelogBB exposes a built-in **Model Context Protocol (MCP)** server that lets AI assistants (e.g. Claude, GitHub Copilot, Cursor) read and interact with your life-log data directly.
 
-The MCP endpoint is available at `/mcp` and requires a **JWT Bearer token** for authentication. Generate a token via the Swagger UI (`/Swagger/`) using the `/api/authentication/token` endpoint with your configured password.
+The MCP endpoint is available at `/mcp` and accepts a **Bearer token** in the `Authorization` header. Two kinds of token work:
+
+* **MCP token (recommended).** Set a long random value under *Config → Chat / AI → MCP Token*. It does not expire, so MCP clients keep working without re-authenticating. Leave the field empty to disable this and allow JWT tokens only.
+* **JWT token.** Generate one via the Swagger UI (`/Swagger/`) using `POST /api/authentication` with your configured password. It expires after `Authentication:JwtToken:TokenTimeoutMinutes` (60 minutes by default).
 
 ### Example MCP configuration (Claude Desktop / mcp.json)
 
@@ -220,14 +223,16 @@ The MCP endpoint is available at `/mcp` and requires a **JWT Bearer token** for 
       "type": "http",
       "url": "https://your-lifelogbb-host/mcp",
       "headers": {
-        "Authorization": "Bearer <your-jwt-token>"
+        "Authorization": "Bearer <your-mcp-token>"
       }
     }
   }
 }
 ```
 
-Replace `https://your-lifelogbb-host` with the URL of your LifelogBB instance and `<your-jwt-token>` with the token obtained above.
+Replace `https://your-lifelogbb-host` with the URL of your LifelogBB instance and `<your-mcp-token>` with the token from the config page.
+
+The MCP token grants full read and write access to all of your life-log data and never expires. Only use it over HTTPS and treat it like a password.
 
 ## Development
 


### PR DESCRIPTION
## Why

The MCP server at `/mcp` could only be used with a JWT from `POST /api/authentication`, which expires after 60 minutes. MCP clients configure static headers in `mcp.json` and have no refresh flow, so the connection broke every hour and a new token had to be fetched from Swagger by hand.

## What

A new `McpToken` in the app config, in the spirit of the existing `FeedToken`: set it once on the config page, paste it into the client, done.

- **Entity + migration** — `Config.McpToken`, `Configs.McpToken` column, EF default `""`.
- **`McpTokenAuthenticationHandler`** (new `"McpToken"` scheme) — reads `Authorization: Bearer <token>`, compares it against the configured value with `CryptographicOperations.FixedTimeEquals`, and emits the same claims as the JWT path. On a mismatch it delegates to JWT bearer, so existing JWT based clients keep working. It overrides the challenge to write a plain `401` instead of redirecting to the cookie login page, which previously handed MCP clients an HTML login form.
- **`Program.cs`** — registers the scheme and routes `/mcp*` to it in the existing `ForwardDefaultSelector`. Everything else keeps the current `Bearer` to JWT / otherwise cookie behaviour.
- **Config page + README** — a plain text field in the Chat / AI card (the value has to be readable to paste it into a client config, same posture as `FeedToken`) and updated docs.

## Notes for the reviewer

**Scope.** The token is only accepted on `/mcp`. The REST API and web UI still require JWT or cookie auth, so a leaked token cannot be replayed against `/api/*`.

**Default is empty, not a placeholder.** Empty means token authentication is off and only JWT works. Deliberately unlike `FeedToken`, whose `ChangeMeInTheConfig` placeholder is public in this repo — shipping that as an accepted value would silently expose full read/write MCP access on every existing installation.

**Unrelated fix included:** `ChatApiKey` is now `[ValidateNever]`. It is blanked on GET and preserved when posted empty, but nullable reference types make non-nullable strings implicitly required, so every config save has been failing with *"The ChatApiKey field is required"* since the chat feature landed unless the key was retyped. It also blocked saving an empty `McpToken`, so the fix was needed here. Happy to split it out if you would rather have it separate.

**Docs correction:** the README and the config page pointed at `/api/authentication/token`; the actual route is `POST /api/authentication`.

## Verified against the running app

Correct token gives 200 plus `tools/list` and a real `GetAllQuotes` call; wrong token gives 401; no header gives 401 with `WWW-Authenticate: Bearer` rather than a 302; empty config value rejects even a previously valid token; an existing JWT still works on `/mcp`; the token is rejected on `/api/weights` (401) while the JWT is accepted (200); anonymous MVC pages still redirect to login; the iCal feed still works. Saving through the real settings form persists the token and leaves an existing `ChatApiKey` intact.

## Out of scope, spotted while working

- `.AddMcp()` is registered but `McpAuthenticationOptions.ResourceMetadata` is never configured, so `/.well-known/oauth-protected-resource/...` throws a 500. No current client hits it.
- `AuthenticationController.Authenticate` carries `[McpServerTool]`, so a password taking `authenticate` tool shows up in `tools/list`. Not an escalation since `/mcp` itself requires auth, but it serves no purpose there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)