### PR TITLE
Fix 500 on the OAuth metadata path and drop the authenticate MCP tool

### DIFF
--- a/LifelogBb/ApiControllers/AuthenticationController.cs
+++ b/LifelogBb/ApiControllers/AuthenticationController.cs
@@ -1,7 +1,6 @@
 ﻿using LifelogBb.Models.Account;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using ModelContextProtocol.Server;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using Westwind.AspNetCore.Security;
@@ -10,7 +9,6 @@ namespace LifelogBb.ApiControllers
 {
     [Route("api/[controller]")]
     [ApiController]
-    [McpServerToolType]
     public class AuthenticationController : ControllerBase
     {
         private readonly IConfiguration Configuration;
@@ -22,7 +20,8 @@ namespace LifelogBb.ApiControllers
 
         [HttpPost]
         [AllowAnonymous]
-        [McpServerTool]
+        // Not an MCP tool. The MCP connection is already authenticated, so exposing a password taking
+        // login tool there has no purpose.
         // [ValidateAntiForgeryToken] // No validation as we use this from Swagger/API as well
         public IActionResult Authenticate([FromBody] LoginModel loginModel)
         {

--- a/LifelogBb/Program.cs
+++ b/LifelogBb/Program.cs
@@ -164,7 +164,9 @@ namespace LifelogBb
             })
             .AddScheme<AuthenticationSchemeOptions, McpTokenAuthenticationHandler>(
                 McpTokenDefaults.AuthenticationScheme, McpTokenDefaults.DisplayName, options => { })
-            .AddMcp()
+            // No AddMcp() here. It only serves OAuth resource metadata discovery, which needs an OAuth
+            // server we do not have. Its handler intercepts /.well-known/oauth-protected-resource and
+            // throws when ResourceMetadata is unset. MCP clients authenticate with the MCP token or a JWT.
             .AddPolicyScheme("JWT_OR_COOKIE", "JWT_OR_COOKIE", options =>
             {
                 options.ForwardDefaultSelector = context =>


### PR DESCRIPTION
Follow-up to #19: the two out-of-scope items flagged there, both small and independent.

## 1. `/.well-known/oauth-protected-resource` returned 500

`.AddMcp()` registers a handler that intercepts `/.well-known/oauth-protected-resource` on every request and throws `InvalidOperationException: ResourceMetadata has not been configured`, because that option was never set. Confirmed on `main` before the fix:

```
GET /.well-known/oauth-protected-resource      -> 500
GET /.well-known/oauth-protected-resource/mcp  -> 500
```

The path is unauthenticated, since the handler runs ahead of authorization. It matters because OAuth capable MCP clients probe it after a 401 — a server error reads as a broken server rather than "no OAuth here, use the header token". In Development it also returns the full stack trace; in Production `UseExceptionHandler` catches it, so it is a plain 500 there.

`.AddMcp()` exists only to serve OAuth resource metadata discovery, and there is no OAuth server to describe — MCP clients authenticate with the MCP token or a JWT. A grep confirms nothing else in the project references the scheme it registers, so the call is removed and those paths now return 404.

## 2. `authenticate` was exposed as an MCP tool

`AuthenticationController` carried `[McpServerToolType]` with `[McpServerTool]` on `Authenticate`, so a password taking `authenticate` tool showed up in `tools/list` next to the 16 data tools.

Not an escalation — `/mcp` requires authentication before any tool can be listed or called, so only an already-authenticated client ever saw it. But it serves no purpose on a connection that is already authenticated, and it invites an assistant to go hunting for the account password. The two attributes and the now unused `using` are removed; the REST endpoint keeps `[HttpPost]` and `[AllowAnonymous]` and is otherwise untouched.

## Verified against the running app

- Both well-known paths: 500 before, **404** after.
- `tools/list`: **16** tools, `authenticate` gone (was 17).
- `POST /api/authentication` still issues a JWT (200, 485 char token) — the REST route survived the attribute removal.
- MCP token gives 200 on `initialize` and a real `GetAllQuotes` call returns data.
- JWT fallback on `/mcp` still 200; wrong token and missing header both 401.
- Token still scoped: `/api/weights` rejects the MCP token (401) and accepts the JWT (200).
- Anonymous MVC pages still redirect to login (302); the iCal feed still works (200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)