### PR TITLE
Fix all build warnings and make number parsing culture independent

### DIFF
--- a/LifelogBb/ApiControllers/AuthenticationController.cs
+++ b/LifelogBb/ApiControllers/AuthenticationController.cs
@@ -1,4 +1,5 @@
 ﻿using LifelogBb.Models.Account;
+using LifelogBb.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.IdentityModel.Tokens.Jwt;
@@ -42,10 +43,10 @@ namespace LifelogBb.ApiControllers
 
                 var token = JwtHelper.GetJwtToken(
                     "Default user",
-                    Configuration["Authentication:JwtToken:SigningKey"],
-                    Configuration["Authentication:JwtToken:Issuer"],
-                    Configuration["Authentication:JwtToken:Audience"],
-                    TimeSpan.FromMinutes(double.Parse(Configuration["Authentication:JwtToken:TokenTimeoutMinutes"])),
+                    Configuration.GetRequired("Authentication:JwtToken:SigningKey"),
+                    Configuration.GetRequired("Authentication:JwtToken:Issuer"),
+                    Configuration.GetRequired("Authentication:JwtToken:Audience"),
+                    TimeSpan.FromMinutes(double.Parse(Configuration.GetRequired("Authentication:JwtToken:TokenTimeoutMinutes"))),
                     claims.ToArray()
                 );
 

--- a/LifelogBb/ApiControllers/AuthenticationController.cs
+++ b/LifelogBb/ApiControllers/AuthenticationController.cs
@@ -46,7 +46,7 @@ namespace LifelogBb.ApiControllers
                     Configuration.GetRequired("Authentication:JwtToken:SigningKey"),
                     Configuration.GetRequired("Authentication:JwtToken:Issuer"),
                     Configuration.GetRequired("Authentication:JwtToken:Audience"),
-                    TimeSpan.FromMinutes(double.Parse(Configuration.GetRequired("Authentication:JwtToken:TokenTimeoutMinutes"))),
+                    TimeSpan.FromMinutes(Configuration.GetRequiredDouble("Authentication:JwtToken:TokenTimeoutMinutes")),
                     claims.ToArray()
                 );
 

--- a/LifelogBb/Controllers/GoalsController.cs
+++ b/LifelogBb/Controllers/GoalsController.cs
@@ -246,7 +246,7 @@ namespace LifelogBb.Controllers
                 calendar.Todos.Add(new Ical.Net.CalendarComponents.Todo()
                 {
                     Uid = goal.Id.ToString(),
-                    Url = new Uri(Url.Action(nameof(Details), nameof(GoalsController).Replace("Controller", ""), new { id = goal.Id }, "https", Request.Host.Value)),
+                    Url = new Uri(Url.Action(nameof(Details), nameof(GoalsController).Replace("Controller", ""), new { id = goal.Id }, "https", Request.Host.Value)!),
                     Summary = goal.Name,
                     Description = $"{goal.Description}\n\nInitial Value: {goal.InitialValue}\nCurrent Value: {goal.CurrentValue}\nTarget Value: {goal.TargetValue}\n",
                     Completed = goal.EndDate.HasValue ? new CalDateTime(goal.EndDate.Value) : null,

--- a/LifelogBb/Controllers/HabitsController.cs
+++ b/LifelogBb/Controllers/HabitsController.cs
@@ -282,7 +282,7 @@ namespace LifelogBb.Controllers
                 var calEvent = new CalendarEvent()
                 {
                     Uid = habit.Id.ToString(),
-                    Url = new Uri(Url.Action(nameof(Details), nameof(HabitsController).Replace("Controller", ""), new { id = habit.Id }, "https", Request.Host.Value)),
+                    Url = new Uri(Url.Action(nameof(Details), nameof(HabitsController).Replace("Controller", ""), new { id = habit.Id }, "https", Request.Host.Value)!),
                     Summary = habit.Name,
                     Description = habit.Description,
                     LastModified = new CalDateTime(habit.UpdatedAt),

--- a/LifelogBb/Controllers/HomeController.cs
+++ b/LifelogBb/Controllers/HomeController.cs
@@ -212,11 +212,11 @@ namespace LifelogBb.Controllers
 
             // Add Due date for todos on forDay (Set start date and end date to due date to show as block)
             var todos = await _context.Todos.Where(t => !t.IsCompleted && t.DueDate != null && t.DueDate.Value.Date == forDay).ToListAsync();
-            model.Events.AddRange(todos.ConvertAll(t => new CalendarViewModelEvent { Type = EntityType.Todo, Text = t.Title, StartDate = t.DueDate.Value, EndDate = t.DueDate.Value }));
+            model.Events.AddRange(todos.ConvertAll(t => new CalendarViewModelEvent { Type = EntityType.Todo, Text = t.Title, StartDate = t.DueDate!.Value, EndDate = t.DueDate!.Value }));
 
             // Add End date for goals on forDay (Set start date to end date to show as block)
             var goals = await _context.Goals.Where(t => !t.IsCompleted && t.EndDate != null && t.EndDate.Value.Date == forDay).ToListAsync();
-            model.Events.AddRange(goals.ConvertAll(g => new CalendarViewModelEvent { Type = EntityType.Goal, Text = g.Name, StartDate = g.EndDate.Value, EndDate = g.EndDate.Value }));
+            model.Events.AddRange(goals.ConvertAll(g => new CalendarViewModelEvent { Type = EntityType.Goal, Text = g.Name, StartDate = g.EndDate!.Value, EndDate = g.EndDate!.Value }));
 
             return View(model);
         }
@@ -266,6 +266,12 @@ namespace LifelogBb.Controllers
             var habitList = new List<Habit>();
             foreach (var habit in allHabits)
             {
+                // Callers already filter these out, but the method has to hold up on its own.
+                if (!habit.StartDate.HasValue || !habit.EndDate.HasValue || string.IsNullOrEmpty(habit.RecurrenceRules))
+                {
+                    continue;
+                }
+
                 var calendar = new Ical.Net.Calendar();
                 calendar.Events.Add(new Ical.Net.CalendarComponents.CalendarEvent
                 {

--- a/LifelogBb/Controllers/TodosController.cs
+++ b/LifelogBb/Controllers/TodosController.cs
@@ -251,7 +251,7 @@ namespace LifelogBb.Controllers
                 calendar.Todos.Add(new CalendarComponents.Todo()
                 {
                     Uid = todo.Id.ToString(),
-                    Url = new Uri(Url.Action(nameof(Details), nameof(TodosController).Replace("Controller", ""), new { id = todo.Id }, "https", Request.Host.Value)),
+                    Url = new Uri(Url.Action(nameof(Details), nameof(TodosController).Replace("Controller", ""), new { id = todo.Id }, "https", Request.Host.Value)!),
                     Summary = todo.Title,
                     Description = todo.Description,
                     Completed = todo.Completed.HasValue ? new CalDateTime(todo.Completed.Value) : null,

--- a/LifelogBb/LifelogBb.csproj
+++ b/LifelogBb/LifelogBb.csproj
@@ -33,6 +33,18 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Transitive dependencies pinned to the first patched version of a security advisory.
+         Remove each entry once the package that pulls it in ships the fixed version itself.
+         Microsoft.OpenApi        <- Swashbuckle.AspNetCore                     GHSA-v5pm-xwqc-g5wc
+         SQLitePCLRaw.lib.*       <- Microsoft.EntityFrameworkCore.Sqlite       GHSA-2m69-gcr7-jv3q
+         NuGet.Packaging/Protocol <- Microsoft.VisualStudio.Web.CodeGeneration  GHSA-g4vj-cjjj-v7hg -->
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.12" />
+    <PackageReference Include="NuGet.Packaging" Version="6.12.5" />
+    <PackageReference Include="NuGet.Protocol" Version="6.12.5" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Folder Include="Migrations\" />
   </ItemGroup>
 

--- a/LifelogBb/Program.cs
+++ b/LifelogBb/Program.cs
@@ -148,7 +148,7 @@ namespace LifelogBb
             .AddCookie(options =>
             {
                 options.LoginPath = "/Account/Login/";
-                options.ExpireTimeSpan = TimeSpan.FromDays(double.Parse(config["Authentication:Cookie:ExpireDays"]));
+                options.ExpireTimeSpan = TimeSpan.FromDays(double.Parse(config.GetRequired("Authentication:Cookie:ExpireDays")));
             })
             .AddJwtBearer(options =>
             {
@@ -159,7 +159,7 @@ namespace LifelogBb
                     ValidateAudience = true,
                     ValidAudience = config["Authentication:JwtToken:Audience"],
                     ValidateIssuerSigningKey = true,
-                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(config["Authentication:JwtToken:SigningKey"]))
+                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(config.GetRequired("Authentication:JwtToken:SigningKey")))
                 };
             })
             .AddScheme<AuthenticationSchemeOptions, McpTokenAuthenticationHandler>(
@@ -177,7 +177,7 @@ namespace LifelogBb
                     if (context.Request.Path.StartsWithSegments("/mcp"))
                         return McpTokenDefaults.AuthenticationScheme;
 
-                    string authorization = context.Request.Headers[HeaderNames.Authorization];
+                    string? authorization = context.Request.Headers[HeaderNames.Authorization];
                     if (!string.IsNullOrEmpty(authorization) && authorization.StartsWith("Bearer "))
                         return JwtBearerDefaults.AuthenticationScheme;
 

--- a/LifelogBb/Program.cs
+++ b/LifelogBb/Program.cs
@@ -148,7 +148,7 @@ namespace LifelogBb
             .AddCookie(options =>
             {
                 options.LoginPath = "/Account/Login/";
-                options.ExpireTimeSpan = TimeSpan.FromDays(double.Parse(config.GetRequired("Authentication:Cookie:ExpireDays")));
+                options.ExpireTimeSpan = TimeSpan.FromDays(config.GetRequiredDouble("Authentication:Cookie:ExpireDays"));
             })
             .AddJwtBearer(options =>
             {

--- a/LifelogBb/Utilities/ConfigurationExtensions.cs
+++ b/LifelogBb/Utilities/ConfigurationExtensions.cs
@@ -1,0 +1,23 @@
+namespace LifelogBb.Utilities;
+
+/// <summary>
+/// Helpers for reading configuration values that the application cannot run without.
+/// </summary>
+public static class ConfigurationExtensions
+{
+    /// <summary>
+    /// Returns the value for <paramref name="key"/> and throws when it is missing or empty.
+    /// Turns a missing setting into a clear error naming the key instead of a null reference
+    /// somewhere further down.
+    /// </summary>
+    public static string GetRequired(this IConfiguration configuration, string key)
+    {
+        var value = configuration[key];
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException($"Required configuration value \"{key}\" is missing.");
+        }
+
+        return value;
+    }
+}

--- a/LifelogBb/Utilities/ConfigurationExtensions.cs
+++ b/LifelogBb/Utilities/ConfigurationExtensions.cs
@@ -20,4 +20,20 @@ public static class ConfigurationExtensions
 
         return value;
     }
+
+    /// <summary>
+    /// Returns the value for <paramref name="key"/> as a number and throws when it is missing or
+    /// not a valid number. Accepts both "1.5" and "1,5" so the same appsettings file works on an
+    /// en and a de machine.
+    /// </summary>
+    public static double GetRequiredDouble(this IConfiguration configuration, string key)
+    {
+        var value = configuration.GetRequired(key);
+        if (!NumberParsing.TryParseDouble(value, out var number))
+        {
+            throw new InvalidOperationException($"Configuration value \"{key}\" is not a valid number: \"{value}\".");
+        }
+
+        return number;
+    }
 }

--- a/LifelogBb/Utilities/ControllerQueryExtensions.cs
+++ b/LifelogBb/Utilities/ControllerQueryExtensions.cs
@@ -64,7 +64,7 @@ namespace LifelogBb.Utilities
         }
 
         // https://learn.microsoft.com/en-us/aspnet/core/data/ef-mvc/advanced?view=aspnetcore-7.0#use-dynamic-linq-to-simplify-code
-        public static IOrderedQueryable<T> SortByName<T>(this IQueryable<T> query, string sortOrder, string defaultSort = "CreatedAt_desc")
+        public static IOrderedQueryable<T> SortByName<T>(this IQueryable<T> query, string sortOrder, string defaultSort = "CreatedAt_desc") where T : class
         {
             // Sorting name is not specified or on the entity => fallback to default to prevent errors
             if (string.IsNullOrEmpty(sortOrder) || query.ElementType.GetProperty(sortOrder.Replace("_desc", "")) == null)
@@ -89,7 +89,7 @@ namespace LifelogBb.Utilities
             }
         }
 
-        public static IQueryable<T> FilterByStringProps<T>(this IQueryable<T> query, string field, string searchString)
+        public static IQueryable<T> FilterByStringProps<T>(this IQueryable<T> query, string field, string searchString) where T : class
         {
             if (string.IsNullOrEmpty(field) || string.IsNullOrEmpty(searchString)) { return query; }
 
@@ -101,7 +101,7 @@ namespace LifelogBb.Utilities
             return query.Where(e => EF.Property<string>(e, field).Contains(searchString));
         }
 
-        public static IQueryable<T> FilterByDoubleProps<T>(this IQueryable<T> query, string field, string searchString, double range)
+        public static IQueryable<T> FilterByDoubleProps<T>(this IQueryable<T> query, string field, string searchString, double range) where T : class
         {
             if (string.IsNullOrEmpty(field) || string.IsNullOrEmpty(searchString)) { return query; }
 

--- a/LifelogBb/Utilities/ControllerQueryExtensions.cs
+++ b/LifelogBb/Utilities/ControllerQueryExtensions.cs
@@ -108,7 +108,8 @@ namespace LifelogBb.Utilities
             var prop = query.ElementType.GetProperty(field);
             if (prop == null) { return query; }
 
-            if (!double.TryParse(searchString, out var searchDouble))
+            // Accepts "80.5" and "80,5" alike, so the search box behaves the same on an en and a de machine.
+            if (!NumberParsing.TryParseDouble(searchString, out var searchDouble))
             {
                 return query;
             }

--- a/LifelogBb/Utilities/ControllerTagsExtensions.cs
+++ b/LifelogBb/Utilities/ControllerTagsExtensions.cs
@@ -15,7 +15,7 @@ namespace LifelogBb.Utilities
             var tagsBucketLists = _context.BucketLists.Select(s => s.Tags).Distinct();
 
             var tags = tagGoals.Union(tagsHabits).Union(tagsJournal).Union(tagsQuotes).Union(tagsTodos).Union(tagsBucketLists).Distinct();            
-            var tagsList = tags.ToList().Where(s => s != null).SelectMany(s => s.Split(',')).Distinct();
+            var tagsList = tags.ToList().OfType<string>().SelectMany(s => s.Split(',')).Distinct();
             var tagsText = string.Join(",", tagsList);
             
             controller.ViewData["TagsList"] = tagsText;

--- a/LifelogBb/Utilities/JwtHelper.cs
+++ b/LifelogBb/Utilities/JwtHelper.cs
@@ -30,7 +30,7 @@ namespace Westwind.AspNetCore.Security
             string issuer,
             string audience,
             TimeSpan expiration,
-            Claim[] additionalClaims = null)
+            Claim[]? additionalClaims = null)
         {
             var claims = new[]
             {
@@ -73,7 +73,7 @@ namespace Westwind.AspNetCore.Security
             string issuer,
             string audience,
             TimeSpan expiration,
-            Claim[] additionalClaims = null)
+            Claim[]? additionalClaims = null)
         {
             var token = GetJwtToken(username, uniqueKey, issuer, audience, expiration, additionalClaims);
             return new JwtSecurityTokenHandler().WriteToken(token);

--- a/LifelogBb/Utilities/NumberParsing.cs
+++ b/LifelogBb/Utilities/NumberParsing.cs
@@ -1,0 +1,45 @@
+using System.Globalization;
+
+namespace LifelogBb.Utilities;
+
+/// <summary>
+/// Number parsing that does not depend on the culture the server happens to run under.
+/// </summary>
+public static class NumberParsing
+{
+    private const NumberStyles Styles = NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint
+        | NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite;
+
+    /// <summary>
+    /// Parses a double written with either the English "1.5" or the German "1,5" decimal separator,
+    /// with the same result on an en and a de machine.
+    /// </summary>
+    /// <remarks>
+    /// A single "." or "," is always read as the decimal separator, so the same input gives the same
+    /// number under every culture. Digit grouping is not supported and cannot be: "1,000" is one
+    /// thousand in en and one in de, so it is read as 1.0 here rather than guessed. Values carrying
+    /// more than one separator ("1,234.56", "1.234.567") are rejected as ambiguous.
+    /// </remarks>
+    public static bool TryParseDouble(string? value, out double result)
+    {
+        result = 0;
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var trimmed = value.Trim();
+        var dots = trimmed.Count(c => c == '.');
+        var commas = trimmed.Count(c => c == ',');
+
+        // Both separators, or one of them repeated, means digit grouping is definitely in play and
+        // the value cannot be read the same way in both cultures.
+        if ((dots > 0 && commas > 0) || dots > 1 || commas > 1)
+        {
+            return false;
+        }
+
+        return double.TryParse(trimmed.Replace(',', '.'), Styles, CultureInfo.InvariantCulture, out result);
+    }
+}

--- a/LifelogBb/Views/Shared/Components/Navigation/Default.cshtml
+++ b/LifelogBb/Views/Shared/Components/Navigation/Default.cshtml
@@ -8,7 +8,7 @@
         {
             if (item.SubItems is not null && item.SubItems.Count > 0)
             {
-                var hasActiveSubItem = item.SubItems.Any(x => x.Controller == ViewContext.RouteData.Values["controller"].ToString() && x.Action == ViewContext.RouteData.Values["action"].ToString());
+                var hasActiveSubItem = item.SubItems.Any(x => x.Controller == ViewContext.RouteData.Values["controller"]?.ToString() && x.Action == ViewContext.RouteData.Values["action"]?.ToString());
                 var activeClass = hasActiveSubItem ? "active" : "";
                 var showSubItems = hasActiveSubItem ? "true" : "false";
                 var showSubItemsClass = hasActiveSubItem ? "show" : "";
@@ -22,7 +22,7 @@
                             <div class="dropdown-menu-column">
                                 @foreach(var subItem in item.SubItems)
                                 {
-                                    var isSubActive = subItem.Controller == ViewContext.RouteData.Values["controller"].ToString() && subItem.Action == ViewContext.RouteData.Values["action"].ToString();
+                                    var isSubActive = subItem.Controller == ViewContext.RouteData.Values["controller"]?.ToString() && subItem.Action == ViewContext.RouteData.Values["action"]?.ToString();
                                     var subActiveClass = isSubActive ? "active" : "";
                                     <a class="dropdown-item @subActiveClass" asp-area="" asp-controller="@subItem.Controller" asp-action="@subItem.Action">
                                         <span class="nav-link-icon d-md-none d-lg-inline-block"><i class="@subItem.Icon"></i></span>


### PR DESCRIPTION
Two related cleanups. The build emitted **24 nullable reference warnings** and **4 NuGet security advisories** — both are now **zero** in Debug and Release. On top of that, number parsing no longer depends on the culture the server runs under.

Each warning is fixed by stating the intent, not by suppressing the analyzer. No `#pragma warning disable`, no `<NoWarn>`.

## 1. Nullable reference warnings (24)

| Fix | Sites |
|---|---|
| **New `IConfiguration.GetRequired`** — required settings went through the indexer, which returns `string?`. The helper throws naming the missing key instead of failing later inside `Encoding.GetBytes` or `double.Parse`. | `Program.cs`, `AuthenticationController.cs` (6) |
| **`where T : class`** on `SortByName`, `FilterByStringProps`, `FilterByDoubleProps` — an unconstrained `T` was passed to `EF.Property`. They are only ever called with entity types. | `ControllerQueryExtensions.cs` (4) |
| **Guard clause in `calculateHabits`** — it dereferenced `StartDate`, `EndDate` and `RecurrenceRules` that only its callers filter. It now skips incomplete habits itself, so the method holds up on its own. | `HomeController.cs` (3) |
| **`OfType<string>()`** replacing `Where(s => s != null)` before `s.Split`, which the compiler cannot narrow. | `ControllerTagsExtensions.cs` (1) |
| **`?.` / `string?`** where the value is genuinely nullable: route value lookups in the navigation view, and the `Authorization` header in the scheme selector. | `Default.cshtml`, `Program.cs` (3) |
| **Nullable parameter** — vendored `JwtHelper` declared `Claim[] additionalClaims = null`. | `JwtHelper.cs` (2) |
| **Null forgiving operator** where an adjacent query filter or a static route already guarantees the value: `DueDate`, `EndDate`, `Url.Action`. | `HomeController.cs`, `Todos/Goals/HabitsController.cs` (5) |

## 2. Security advisories (4)

All four are transitive. Each is pinned to the **first patched version inside the same release line**, so the delta stays small:

| Package | Advisory | Bump | Pulled in by |
|---|---|---|---|
| Microsoft.OpenApi | GHSA-v5pm-xwqc-g5wc (high) | 2.4.1 → **2.7.5** | Swashbuckle.AspNetCore |
| SQLitePCLRaw.lib.e_sqlite3 | GHSA-2m69-gcr7-jv3q (high) | 2.1.11 → **2.1.12** | EntityFrameworkCore.Sqlite |
| NuGet.Packaging | GHSA-g4vj-cjjj-v7hg (low) | 6.12.1 → **6.12.5** | Web.CodeGeneration.Design |
| NuGet.Protocol | GHSA-g4vj-cjjj-v7hg (low) | 6.12.1 → **6.12.5** | Web.CodeGeneration.Design |

Deliberately **not** taken: Microsoft.OpenApi 3.x, which would be a major jump away from what Swashbuckle 10.1.7 expects. 2.7.5 is the lowest version the advisory considers patched. The csproj records which parent pulls each one in, so the pins can be dropped once those ship the fix themselves.

## 3. Culture independent number parsing

`double.Parse` / `double.TryParse` without a format provider use the culture the server happens to run under, so the same input produced **different numbers on an en and a de machine**:

- `ExpireDays` of `"1.5"` became **15 days** on a German host.
- A weight search for `"82.5"` found nothing on a German host; `"82,5"` found nothing on an English one.

New `NumberParsing.TryParseDouble` reads a single `.` or `,` as the decimal separator, so both notations give the same result under every culture. Used by the new `IConfiguration.GetRequiredDouble` (cookie expiry, JWT timeout) and by `FilterByDoubleProps` (weight search box).

Digit grouping is not supported and cannot be: `"1,000"` is one thousand in en and one in de, so it is read as **1.0** rather than guessed, and values with more than one separator (`"1,234.56"`) are rejected as ambiguous. For days, minutes and body weights that trade is right; the alternative is silently being wrong by a factor of a thousand.

`DynamicFilterBuilder` is deliberately left alone — it already parses with `InvariantCulture`, and its values come from jQuery QueryBuilder `number` inputs, which are always invariant on the wire.

## Behaviour changes worth reviewing

1. **An invalid or missing required config value now throws with a clear message**, e.g. `Configuration value "Authentication:Cookie:ExpireDays" is not a valid number: "abc".` Note this surfaces on the first request that touches the relevant options (the `AddCookie`/`AddJwtBearer` delegates are lazy), not at startup. Previously it was a `NullReferenceException` or a silently wrong number.
2. **`calculateHabits` skips a habit with no start date, no end date, or no recurrence rule** instead of throwing. Callers already filter these, so the observable result is unchanged.

## Verified against the running app

`dotnet build -t:Rebuild` in Debug **and** Release: `0 Warnung(en), 0 Fehler`. `dotnet list package --vulnerable --include-transitive`: no vulnerable packages.

Functionally, after logging in through the real form: all 14 MVC pages return 200; sorting and filtering work, exercising the newly constrained generics; the navigation still computes its active state; all three iCal feeds emit a `URL:` line for every entry; all 5 seeded habits pass the new guard and the daily ones render on the calendar; JWT issuance, MCP with the static token, MCP with a JWT, 401 on a wrong token, and the REST API all behave as before; Swagger still generates (`openapi 3.0.4`, 17 paths) under the bumped Microsoft.OpenApi. No exceptions in the application log.

For the culture work, the same requests were run against **two instances under different cultures** — the machine default (de) and one forced to invariant globalization — with identical results:

| Request | de instance | invariant instance |
|---|---|---|
| `/Weights/Table` unfiltered | 20 rows | 20 rows |
| `searchString=82.5` | 4 rows | 4 rows |
| `searchString=82,5` | 4 rows | 4 rows |
| `searchString=200` (control) | 0 rows | 0 rows |
| `searchString=1,234.56` (ambiguous) | unfiltered | unfiltered |

4 rows is exactly what the seed data contains within `82.5 ± 1.0`. The cookie lifetime came out at 1.5 days from `ExpireDays="1,5"` on the de instance and from `"1.5"` on the invariant one, and an `ExpireDays="abc"` run produced the named error above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)