### PR TITLE
Add a built-in OAuth 2.1 server for MCP clients

### DIFF
--- a/LifelogBb/Controllers/AccountController.cs
+++ b/LifelogBb/Controllers/AccountController.cs
@@ -18,15 +18,15 @@ namespace LifelogBb.Controllers
         }
 
         [AllowAnonymous]
-        public IActionResult Login()
+        public IActionResult Login(string? returnUrl = null)
         {
-            return View();
+            return View(new LoginModel { ReturnUrl = returnUrl });
         }
 
         [HttpPost]
         [AllowAnonymous]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Login([Bind("Password")] LoginModel loginModel)
+        public async Task<IActionResult> Login([Bind("Password,ReturnUrl")] LoginModel loginModel)
         {
             // TODO Add documentation hint to secure password instead of using appsettings.json file
             // https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-6.0
@@ -44,11 +44,17 @@ namespace LifelogBb.Controllers
 
                 var authProperties = new AuthenticationProperties
                 {
-                    RedirectUri = "/Index",
                     IsPersistent = true,
                 };
 
                 await HttpContext.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, new ClaimsPrincipal(claimsIdentity), authProperties);
+
+                // IsLocalUrl keeps a crafted ReturnUrl from turning the login page into an open redirect.
+                if (!string.IsNullOrEmpty(loginModel.ReturnUrl) && Url.IsLocalUrl(loginModel.ReturnUrl))
+                {
+                    return LocalRedirect(loginModel.ReturnUrl);
+                }
+
                 return RedirectToAction(actionName: "Index", controllerName: "Home");
             }
 

--- a/LifelogBb/Controllers/OAuthController.cs
+++ b/LifelogBb/Controllers/OAuthController.cs
@@ -119,6 +119,10 @@ namespace LifelogBb.Controllers
         /// Dynamic client registration (RFC 7591). Only public clients are accepted, so no secret is
         /// ever issued or stored. Anyone who can reach the instance can register, but a registration
         /// on its own grants nothing: a token still requires the app password at the consent step.
+        ///
+        /// No antiforgery token, and there cannot be one: the caller is a non browser HTTP client with
+        /// no session and no way to obtain one. Nothing here acts on an existing session either, so
+        /// there is no cross site request to forge.
         /// </summary>
         [HttpPost("~/oauth/register")]
         [AllowAnonymous]
@@ -201,7 +205,8 @@ namespace LifelogBb.Controllers
             _context.OAuthClients.Add(client);
             await _context.SaveChangesAsync();
 
-            _logger.LogInformation("Registered OAuth client {ClientName} ({ClientId}).", client.ClientName, client.ClientId);
+            _logger.LogInformation("Registered OAuth client {ClientName} ({ClientId}).",
+                LogSanitizer.ForLog(client.ClientName), client.ClientId);
 
             return StatusCode(StatusCodes.Status201Created, BuildRegistrationResponse(client));
         }
@@ -321,7 +326,8 @@ namespace LifelogBb.Controllers
 
             await _context.SaveChangesAsync();
 
-            _logger.LogInformation("Issued an authorization code to {ClientName} ({ClientId}).", client.ClientName, client.ClientId);
+            _logger.LogInformation("Issued an authorization code to {ClientName} ({ClientId}).",
+                LogSanitizer.ForLog(client.ClientName), client.ClientId);
 
             return Redirect(QueryHelpers.AddQueryString(model.RedirectUri!, new Dictionary<string, string?>
             {
@@ -421,8 +427,10 @@ namespace LifelogBb.Controllers
             if (!string.IsNullOrEmpty(model.Resource) && model.Resource != expectedResource)
             {
                 // Recorded but not enforced, see the audience note in the README.
+                // Both values are attacker reachable: the resource comes straight from the query and
+                // the expected value is built from the Host header.
                 _logger.LogWarning("Authorization request asked for resource {Resource}, expected {Expected}.",
-                    model.Resource, expectedResource);
+                    LogSanitizer.ForLog(model.Resource), LogSanitizer.ForLog(expectedResource));
             }
 
             return null;

--- a/LifelogBb/Controllers/OAuthController.cs
+++ b/LifelogBb/Controllers/OAuthController.cs
@@ -1,0 +1,653 @@
+using LifelogBb.Models;
+using LifelogBb.Models.Entities;
+using LifelogBb.Models.OAuth;
+using LifelogBb.Utilities;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.EntityFrameworkCore;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Westwind.AspNetCore.Security;
+
+namespace LifelogBb.Controllers
+{
+    /// <summary>
+    /// A minimal OAuth 2.1 authorization server for MCP clients that cannot use the static MCP
+    /// token, most notably the Claude connectors. It covers protected resource metadata (RFC 9728),
+    /// authorization server metadata (RFC 8414), dynamic client registration (RFC 7591) and the
+    /// authorization code flow with mandatory PKCE.
+    ///
+    /// The resource owner is the single app password, so the authorization endpoint simply reuses
+    /// the normal cookie login. Access tokens are the same JWTs /api/authentication issues, which is
+    /// why no change to the /mcp authentication is needed to accept them.
+    ///
+    /// AllowAnonymous is deliberately per action instead of on the class: any IAllowAnonymous in the
+    /// endpoint metadata would also switch off the Authorize attribute on the authorize endpoints.
+    /// </summary>
+    [RequireOAuthEnabled]
+    public class OAuthController : Controller
+    {
+        private const string CookieScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+
+        /// <summary>Throttles the opportunistic cleanup of expired grants. Process wide.</summary>
+        private static long _lastSweepTicks;
+
+        private readonly LifelogBbContext _context;
+        private readonly IConfiguration _configuration;
+        private readonly ILogger<OAuthController> _logger;
+
+        public OAuthController(LifelogBbContext context, IConfiguration configuration, ILogger<OAuthController> logger)
+        {
+            _context = context;
+            _configuration = configuration;
+            _logger = logger;
+        }
+
+        #region Discovery
+
+        /// <summary>
+        /// Protected resource metadata (RFC 9728). Clients find this through the resource_metadata
+        /// parameter of the 401 challenge on /mcp. The catch all serves both the bare path and the
+        /// "/mcp" suffixed variant clients derive from the resource path.
+        /// </summary>
+        [HttpGet("~/.well-known/oauth-protected-resource")]
+        [HttpGet("~/.well-known/oauth-protected-resource/{*resourcePath}")]
+        [AllowAnonymous]
+        public IActionResult ProtectedResourceMetadata(string? resourcePath)
+        {
+            if (resourcePath is not (null or "mcp"))
+            {
+                return NotFound();
+            }
+
+            var baseUrl = PublicUrl.GetBaseUrl(Request, _configuration);
+            return MetadataJson(new
+            {
+                resource = $"{baseUrl}{OAuthDefaults.ResourcePath}",
+                authorization_servers = new[] { baseUrl },
+                scopes_supported = new[] { OAuthDefaults.Scope },
+                bearer_methods_supported = new[] { "header" },
+                resource_name = "LifelogBB MCP"
+            });
+        }
+
+        /// <summary>
+        /// Authorization server metadata (RFC 8414). The issuer has to be byte for byte the base URL
+        /// the document was fetched from, so it is derived from the request and never from the JWT
+        /// issuer setting, which describes the token and not this endpoint.
+        /// </summary>
+        [HttpGet("~/.well-known/oauth-authorization-server")]
+        [HttpGet("~/.well-known/oauth-authorization-server/{*issuerPath}")]
+        [AllowAnonymous]
+        public IActionResult AuthorizationServerMetadata(string? issuerPath)
+        {
+            if (issuerPath is not (null or "mcp"))
+            {
+                return NotFound();
+            }
+
+            var baseUrl = PublicUrl.GetBaseUrl(Request, _configuration);
+            return MetadataJson(new
+            {
+                issuer = baseUrl,
+                authorization_endpoint = $"{baseUrl}/oauth/authorize",
+                token_endpoint = $"{baseUrl}/oauth/token",
+                registration_endpoint = $"{baseUrl}/oauth/register",
+                scopes_supported = new[] { OAuthDefaults.Scope },
+                response_types_supported = new[] { "code" },
+                response_modes_supported = new[] { "query" },
+                grant_types_supported = new[] { "authorization_code", "refresh_token" },
+                token_endpoint_auth_methods_supported = new[] { "none" },
+                code_challenge_methods_supported = new[] { "S256" }
+            });
+        }
+
+        private IActionResult MetadataJson(object metadata)
+        {
+            Response.Headers.CacheControl = "public, max-age=300";
+            return Json(metadata);
+        }
+
+        #endregion
+
+        #region Dynamic client registration
+
+        /// <summary>
+        /// Dynamic client registration (RFC 7591). Only public clients are accepted, so no secret is
+        /// ever issued or stored. Anyone who can reach the instance can register, but a registration
+        /// on its own grants nothing: a token still requires the app password at the consent step.
+        /// </summary>
+        [HttpPost("~/oauth/register")]
+        [AllowAnonymous]
+        [Consumes("application/json")]
+        [RequestSizeLimit(16 * 1024)]
+        public async Task<IActionResult> Register([FromBody] ClientRegistrationRequest request)
+        {
+            if (request?.RedirectUris is null || request.RedirectUris.Length == 0)
+            {
+                return OAuthError("invalid_client_metadata", "redirect_uris is required.");
+            }
+
+            if (request.RedirectUris.Length > OAuthDefaults.MaxRedirectUrisPerClient)
+            {
+                return OAuthError("invalid_client_metadata", $"At most {OAuthDefaults.MaxRedirectUrisPerClient} redirect URIs are supported.");
+            }
+
+            foreach (var redirectUri in request.RedirectUris)
+            {
+                if (!IsAllowedRedirectUri(redirectUri))
+                {
+                    return OAuthError("invalid_redirect_uri", $"Unsupported redirect URI '{redirectUri}'. Use https, or http on a loopback host.");
+                }
+            }
+
+            if (!string.IsNullOrEmpty(request.TokenEndpointAuthMethod) && request.TokenEndpointAuthMethod != "none")
+            {
+                return OAuthError("invalid_client_metadata", "Only public clients are supported, token_endpoint_auth_method must be 'none'.");
+            }
+
+            if (request.GrantTypes is not null &&
+                request.GrantTypes.Any(g => g is not ("authorization_code" or "refresh_token")))
+            {
+                return OAuthError("invalid_client_metadata", "Only the authorization_code and refresh_token grants are supported.");
+            }
+
+            if (request.ResponseTypes is not null && request.ResponseTypes.Any(r => r != "code"))
+            {
+                return OAuthError("invalid_client_metadata", "Only the 'code' response type is supported.");
+            }
+
+            var clientName = string.IsNullOrWhiteSpace(request.ClientName)
+                ? "MCP client"
+                : request.ClientName.Trim();
+            if (clientName.Length > OAuthDefaults.MaxClientNameLength)
+            {
+                clientName = clientName[..OAuthDefaults.MaxClientNameLength];
+            }
+
+            var redirectUris = string.Join('\n', request.RedirectUris.Select(u => u.Trim()));
+
+            // Clients re-register on every reconnect. Returning the existing record keeps the table
+            // from growing one row per connection attempt.
+            var existing = await _context.OAuthClients
+                .FirstOrDefaultAsync(c => c.RedirectUris == redirectUris && c.ClientName == clientName);
+            if (existing is not null)
+            {
+                return Json(BuildRegistrationResponse(existing));
+            }
+
+            var unusedCutoff = DateTime.UtcNow - OAuthDefaults.UnusedClientLifetime;
+            await _context.OAuthClients
+                .Where(c => c.LastUsedAt == null && c.CreatedAt < unusedCutoff)
+                .ExecuteDeleteAsync();
+
+            if (await _context.OAuthClients.CountAsync() >= OAuthDefaults.MaxClients)
+            {
+                return OAuthError("invalid_client_metadata", "Client registration limit reached.");
+            }
+
+            var client = new OAuthClient
+            {
+                ClientId = OAuthCrypto.NewSecret(16),
+                ClientName = clientName,
+                RedirectUris = redirectUris,
+                Scope = OAuthDefaults.Scope
+            };
+            client.SetCreateFields();
+
+            _context.OAuthClients.Add(client);
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation("Registered OAuth client {ClientName} ({ClientId}).", client.ClientName, client.ClientId);
+
+            return StatusCode(StatusCodes.Status201Created, BuildRegistrationResponse(client));
+        }
+
+        private static object BuildRegistrationResponse(OAuthClient client) => new
+        {
+            client_id = client.ClientId,
+            client_id_issued_at = new DateTimeOffset(client.CreatedAt, TimeSpan.Zero).ToUnixTimeSeconds(),
+            client_name = client.ClientName,
+            redirect_uris = client.RedirectUriList,
+            grant_types = new[] { "authorization_code", "refresh_token" },
+            response_types = new[] { "code" },
+            token_endpoint_auth_method = "none",
+            scope = client.Scope
+        };
+
+        /// <summary>
+        /// https only, except on a loopback host where a local client cannot get a certificate.
+        /// Fragments are rejected because a redirect URI must not carry one.
+        /// </summary>
+        private static bool IsAllowedRedirectUri(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value) || value.Length > OAuthDefaults.MaxUriLength)
+            {
+                return false;
+            }
+
+            if (!Uri.TryCreate(value.Trim(), UriKind.Absolute, out var uri) || !string.IsNullOrEmpty(uri.Fragment))
+            {
+                return false;
+            }
+
+            return uri.Scheme == Uri.UriSchemeHttps || (uri.Scheme == Uri.UriSchemeHttp && uri.IsLoopback);
+        }
+
+        #endregion
+
+        #region Authorization endpoint
+
+        /// <summary>
+        /// The consent screen.
+        /// </summary>
+        [HttpGet("~/oauth/authorize")]
+        [AllowAnonymous]
+        public async Task<IActionResult> Authorize(AuthorizeViewModel model)
+        {
+            var challenge = await RequireInteractiveLoginAsync();
+            if (challenge is not null)
+            {
+                return challenge;
+            }
+
+            var (client, failure) = await ResolveClientAsync(model);
+            if (failure is not null)
+            {
+                return failure;
+            }
+
+            var invalid = ValidateAuthorizeRequest(model);
+            if (invalid is not null)
+            {
+                return invalid;
+            }
+
+            model.ClientName = client!.ClientName;
+            model.GrantedScope = OAuthDefaults.Scope;
+            return View(model);
+        }
+
+        [HttpPost("~/oauth/authorize")]
+        [AllowAnonymous]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Authorize(AuthorizeViewModel model, string decision)
+        {
+            var challenge = await RequireInteractiveLoginAsync();
+            if (challenge is not null)
+            {
+                return challenge;
+            }
+
+            // The hidden fields are attacker controllable, so the full validation runs again.
+            var (client, failure) = await ResolveClientAsync(model);
+            if (failure is not null)
+            {
+                return failure;
+            }
+
+            var invalid = ValidateAuthorizeRequest(model);
+            if (invalid is not null)
+            {
+                return invalid;
+            }
+
+            if (decision != "approve")
+            {
+                return RedirectWithError(model, "access_denied", "The user denied the request.");
+            }
+
+            var code = OAuthCrypto.NewSecret();
+            var grant = new OAuthGrant
+            {
+                GrantType = OAuthGrantType.AuthorizationCode,
+                OAuthClientId = client!.Id,
+                TokenHash = OAuthCrypto.Sha256Hex(code),
+                SessionId = OAuthCrypto.NewSecret(16),
+                RedirectUri = model.RedirectUri,
+                CodeChallenge = model.CodeChallenge,
+                Scope = OAuthDefaults.Scope,
+                Resource = model.Resource,
+                ExpiresAt = DateTime.UtcNow.Add(OAuthDefaults.CodeLifetime)
+            };
+            grant.SetCreateFields();
+            _context.OAuthGrants.Add(grant);
+
+            client.LastUsedAt = DateTime.UtcNow;
+            client.SetUpdateFields();
+
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation("Issued an authorization code to {ClientName} ({ClientId}).", client.ClientName, client.ClientId);
+
+            return Redirect(QueryHelpers.AddQueryString(model.RedirectUri!, new Dictionary<string, string?>
+            {
+                ["code"] = code,
+                ["state"] = model.State
+            }));
+        }
+
+        /// <summary>
+        /// Only a real browser session may grant consent. The check happens here rather than through
+        /// an Authorize attribute for two reasons: attribute metadata is handled by the authorization
+        /// middleware, which would redirect to the login page before RequireOAuthEnabled can hide the
+        /// endpoint, and authenticating the cookie scheme explicitly stops a bearer token from
+        /// approving a fresh grant for itself.
+        /// </summary>
+        private async Task<IActionResult?> RequireInteractiveLoginAsync()
+        {
+            var result = await HttpContext.AuthenticateAsync(CookieScheme);
+            if (result.Succeeded)
+            {
+                return null;
+            }
+
+            // The cookie handler builds the login redirect with the current URL as ReturnUrl, which is
+            // what brings the browser back to this authorization request after signing in.
+            return Challenge(CookieScheme);
+        }
+
+        /// <summary>
+        /// Resolves the client and pins down the redirect URI. These two failures must never be
+        /// redirected: without a verified redirect URI there is nowhere trustworthy to send them.
+        /// </summary>
+        private async Task<(OAuthClient? Client, IActionResult? Failure)> ResolveClientAsync(AuthorizeViewModel model)
+        {
+            if (string.IsNullOrWhiteSpace(model.ClientId))
+            {
+                return (null, ErrorView("invalid_client", "The client_id parameter is missing."));
+            }
+
+            var client = await _context.OAuthClients.FirstOrDefaultAsync(c => c.ClientId == model.ClientId);
+            if (client is null)
+            {
+                return (null, ErrorView("invalid_client", "Unknown client_id. The client has to register again."));
+            }
+
+            var registered = client.RedirectUriList;
+            if (string.IsNullOrWhiteSpace(model.RedirectUri))
+            {
+                if (registered.Count != 1)
+                {
+                    return (null, ErrorView("invalid_request", "The redirect_uri parameter is required for this client."));
+                }
+
+                model.RedirectUri = registered[0];
+            }
+            else if (!registered.Contains(model.RedirectUri, StringComparer.Ordinal))
+            {
+                return (null, ErrorView("invalid_redirect_uri", "The redirect_uri is not registered for this client."));
+            }
+
+            return (client, null);
+        }
+
+        /// <summary>
+        /// Everything the client can be told about by redirecting back to its verified redirect URI.
+        /// </summary>
+        private IActionResult? ValidateAuthorizeRequest(AuthorizeViewModel model)
+        {
+            if (model.ResponseType != "code")
+            {
+                return RedirectWithError(model, "unsupported_response_type", "Only the 'code' response type is supported.");
+            }
+
+            if (string.IsNullOrEmpty(model.CodeChallenge))
+            {
+                return RedirectWithError(model, "invalid_request", "PKCE is required, code_challenge is missing.");
+            }
+
+            // RFC 7636 treats a missing method as 'plain'. Rejecting it explicitly keeps a downgrade
+            // from silently succeeding.
+            if (model.CodeChallengeMethod != "S256")
+            {
+                return RedirectWithError(model, "invalid_request", "code_challenge_method must be S256.");
+            }
+
+            if (!OAuthCrypto.IsValidPkceValue(model.CodeChallenge))
+            {
+                return RedirectWithError(model, "invalid_request", "The code_challenge is malformed.");
+            }
+
+            if (model.State is { Length: > OAuthDefaults.MaxStateLength })
+            {
+                return RedirectWithError(model, "invalid_request", "The state parameter is too long.");
+            }
+
+            var expectedResource = $"{PublicUrl.GetBaseUrl(Request, _configuration)}{OAuthDefaults.ResourcePath}";
+            if (!string.IsNullOrEmpty(model.Resource) && model.Resource != expectedResource)
+            {
+                // Recorded but not enforced, see the audience note in the README.
+                _logger.LogWarning("Authorization request asked for resource {Resource}, expected {Expected}.",
+                    model.Resource, expectedResource);
+            }
+
+            return null;
+        }
+
+        private IActionResult RedirectWithError(AuthorizeViewModel model, string error, string description) =>
+            Redirect(QueryHelpers.AddQueryString(model.RedirectUri!, new Dictionary<string, string?>
+            {
+                ["error"] = error,
+                ["error_description"] = description,
+                ["state"] = model.State
+            }));
+
+        private IActionResult ErrorView(string error, string description)
+        {
+            Response.StatusCode = StatusCodes.Status400BadRequest;
+            return View("Error", new OAuthErrorViewModel { Error = error, Description = description });
+        }
+
+        #endregion
+
+        #region Token endpoint
+
+        /// <summary>
+        /// No antiforgery token here: the endpoint is unauthenticated and its security comes from the
+        /// authorization code plus the PKCE verifier, neither of which an attacker's page can supply.
+        /// </summary>
+        [HttpPost("~/oauth/token")]
+        [AllowAnonymous]
+        [Consumes("application/x-www-form-urlencoded")]
+        [RequestSizeLimit(16 * 1024)]
+        public async Task<IActionResult> Token([FromForm] TokenRequest form)
+        {
+            Response.Headers.CacheControl = "no-store";
+            Response.Headers.Pragma = "no-cache";
+
+            await SweepExpiredGrantsAsync();
+
+            return form.GrantType switch
+            {
+                "authorization_code" => await ExchangeAuthorizationCodeAsync(form),
+                "refresh_token" => await ExchangeRefreshTokenAsync(form),
+                _ => OAuthError("unsupported_grant_type", "Only authorization_code and refresh_token are supported.")
+            };
+        }
+
+        private async Task<IActionResult> ExchangeAuthorizationCodeAsync(TokenRequest form)
+        {
+            if (string.IsNullOrEmpty(form.Code))
+            {
+                return OAuthError("invalid_request", "The code parameter is missing.");
+            }
+
+            var grant = await _context.OAuthGrants
+                .Include(g => g.Client)
+                .FirstOrDefaultAsync(g => g.TokenHash == OAuthCrypto.Sha256Hex(form.Code)
+                                       && g.GrantType == OAuthGrantType.AuthorizationCode);
+
+            if (grant is null)
+            {
+                return OAuthError("invalid_grant", "Unknown authorization code.");
+            }
+
+            if (grant.ConsumedAt is not null)
+            {
+                return await RevokeLineageAsync(grant, "The authorization code was already used.");
+            }
+
+            // Burn the code before anything else so two concurrent requests cannot both redeem it.
+            grant.ConsumedAt = DateTime.UtcNow;
+            grant.SetUpdateFields();
+            await _context.SaveChangesAsync();
+
+            if (grant.ExpiresAt < DateTime.UtcNow)
+            {
+                return OAuthError("invalid_grant", "The authorization code expired.");
+            }
+
+            if (grant.Client!.ClientId != form.ClientId)
+            {
+                return OAuthError("invalid_grant", "The authorization code was issued to a different client.");
+            }
+
+            if (!string.Equals(grant.RedirectUri, form.RedirectUri, StringComparison.Ordinal))
+            {
+                return OAuthError("invalid_grant", "The redirect_uri does not match the authorization request.");
+            }
+
+            if (!OAuthCrypto.IsValidPkceValue(form.CodeVerifier) ||
+                !OAuthCrypto.VerifyPkceS256(form.CodeVerifier!, grant.CodeChallenge!))
+            {
+                return OAuthError("invalid_grant", "PKCE verification failed.");
+            }
+
+            return await IssueTokensAsync(grant.Client, grant.SessionId, grant.Resource);
+        }
+
+        private async Task<IActionResult> ExchangeRefreshTokenAsync(TokenRequest form)
+        {
+            if (string.IsNullOrEmpty(form.RefreshToken))
+            {
+                return OAuthError("invalid_request", "The refresh_token parameter is missing.");
+            }
+
+            var grant = await _context.OAuthGrants
+                .Include(g => g.Client)
+                .FirstOrDefaultAsync(g => g.TokenHash == OAuthCrypto.Sha256Hex(form.RefreshToken)
+                                       && g.GrantType == OAuthGrantType.RefreshToken);
+
+            if (grant is null)
+            {
+                return OAuthError("invalid_grant", "Unknown refresh token.");
+            }
+
+            if (grant.ConsumedAt is not null)
+            {
+                return await RevokeLineageAsync(grant, "The refresh token was already used.");
+            }
+
+            if (grant.ExpiresAt < DateTime.UtcNow)
+            {
+                return OAuthError("invalid_grant", "The refresh token expired.");
+            }
+
+            if (grant.Client!.ClientId != form.ClientId)
+            {
+                return OAuthError("invalid_grant", "The refresh token was issued to a different client.");
+            }
+
+            grant.ConsumedAt = DateTime.UtcNow;
+            grant.SetUpdateFields();
+            await _context.SaveChangesAsync();
+
+            return await IssueTokensAsync(grant.Client, grant.SessionId, grant.Resource);
+        }
+
+        /// <summary>
+        /// Replaying any grant of a chain means either the client is broken or a token leaked, so the
+        /// whole chain goes (RFC 9700 refresh token reuse detection).
+        /// </summary>
+        private async Task<IActionResult> RevokeLineageAsync(OAuthGrant grant, string description)
+        {
+            _logger.LogWarning("Replayed OAuth grant for session {SessionId}, revoking the whole chain.", grant.SessionId);
+            await _context.OAuthGrants.Where(g => g.SessionId == grant.SessionId).ExecuteDeleteAsync();
+            return OAuthError("invalid_grant", description);
+        }
+
+        private async Task<IActionResult> IssueTokensAsync(OAuthClient client, string sessionId, string? resource)
+        {
+            var refreshToken = OAuthCrypto.NewSecret();
+            var refreshGrant = new OAuthGrant
+            {
+                GrantType = OAuthGrantType.RefreshToken,
+                OAuthClientId = client.Id,
+                TokenHash = OAuthCrypto.Sha256Hex(refreshToken),
+                SessionId = sessionId,
+                Scope = OAuthDefaults.Scope,
+                Resource = resource,
+                ExpiresAt = DateTime.UtcNow.Add(OAuthDefaults.RefreshLifetime)
+            };
+            refreshGrant.SetCreateFields();
+            _context.OAuthGrants.Add(refreshGrant);
+
+            client.LastUsedAt = DateTime.UtcNow;
+            client.SetUpdateFields();
+
+            await _context.SaveChangesAsync();
+
+            // Same claims and settings as /api/authentication, so the already configured JwtBearer
+            // handler validates these tokens on /mcp without any extra wiring.
+            var claims = new List<Claim>
+            {
+                new Claim(ClaimTypes.Name, "Default user"),
+                new Claim(ClaimTypes.Role, "Administrator"),
+            };
+
+            var lifetime = TimeSpan.FromMinutes(double.Parse(_configuration["Authentication:JwtToken:TokenTimeoutMinutes"]!));
+            var token = JwtHelper.GetJwtToken(
+                "Default user",
+                _configuration["Authentication:JwtToken:SigningKey"]!,
+                _configuration["Authentication:JwtToken:Issuer"]!,
+                _configuration["Authentication:JwtToken:Audience"]!,
+                lifetime,
+                claims.ToArray()
+            );
+
+            return Json(new
+            {
+                access_token = new JwtSecurityTokenHandler().WriteToken(token),
+                token_type = "Bearer",
+                expires_in = (int)lifetime.TotalSeconds,
+                refresh_token = refreshToken,
+                scope = OAuthDefaults.Scope
+            });
+        }
+
+        /// <summary>
+        /// Cheap cleanup on the token endpoint instead of a hosted service. Consumed and expired rows
+        /// are kept for a day so a replay is still recognised rather than looking like an unknown code.
+        /// </summary>
+        private async Task SweepExpiredGrantsAsync()
+        {
+            var now = DateTime.UtcNow.Ticks;
+            var last = Interlocked.Read(ref _lastSweepTicks);
+            if (last != 0 && now - last < OAuthDefaults.SweepInterval.Ticks)
+            {
+                return;
+            }
+
+            if (Interlocked.CompareExchange(ref _lastSweepTicks, now, last) != last)
+            {
+                return;
+            }
+
+            var cutoff = DateTime.UtcNow - OAuthDefaults.ExpiredGrantRetention;
+            var removed = await _context.OAuthGrants.Where(g => g.ExpiresAt < cutoff).ExecuteDeleteAsync();
+            if (removed > 0)
+            {
+                _logger.LogInformation("Removed {Count} expired OAuth grants.", removed);
+            }
+        }
+
+        #endregion
+
+        private IActionResult OAuthError(string error, string? description = null, int statusCode = StatusCodes.Status400BadRequest) =>
+            StatusCode(statusCode, new { error, error_description = description });
+    }
+}

--- a/LifelogBb/Migrations/20260802183505_OAuthServer.Designer.cs
+++ b/LifelogBb/Migrations/20260802183505_OAuthServer.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LifelogBb.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LifelogBb.Migrations
 {
     [DbContext(typeof(LifelogBbContext))]
-    partial class LifelogBbContextModelSnapshot : ModelSnapshot
+    [Migration("20260802183505_OAuthServer")]
+    partial class OAuthServer
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/LifelogBb/Migrations/20260802183505_OAuthServer.cs
+++ b/LifelogBb/Migrations/20260802183505_OAuthServer.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LifelogBb.Migrations
+{
+    /// <inheritdoc />
+    public partial class OAuthServer : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "McpOAuthEnabled",
+                table: "Configs",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.CreateTable(
+                name: "OAuthClients",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    ClientId = table.Column<string>(type: "TEXT", maxLength: 64, nullable: false),
+                    ClientName = table.Column<string>(type: "TEXT", maxLength: 200, nullable: false),
+                    RedirectUris = table.Column<string>(type: "TEXT", nullable: false),
+                    Scope = table.Column<string>(type: "TEXT", maxLength: 200, nullable: false),
+                    LastUsedAt = table.Column<DateTime>(type: "TEXT", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OAuthClients", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OAuthGrants",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    GrantType = table.Column<int>(type: "INTEGER", nullable: false),
+                    OAuthClientId = table.Column<long>(type: "INTEGER", nullable: false),
+                    TokenHash = table.Column<string>(type: "TEXT", maxLength: 64, nullable: false),
+                    SessionId = table.Column<string>(type: "TEXT", maxLength: 64, nullable: false),
+                    RedirectUri = table.Column<string>(type: "TEXT", maxLength: 2000, nullable: true),
+                    CodeChallenge = table.Column<string>(type: "TEXT", maxLength: 200, nullable: true),
+                    Scope = table.Column<string>(type: "TEXT", maxLength: 200, nullable: false),
+                    Resource = table.Column<string>(type: "TEXT", maxLength: 2000, nullable: true),
+                    ExpiresAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    ConsumedAt = table.Column<DateTime>(type: "TEXT", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OAuthGrants", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_OAuthGrants_OAuthClients_OAuthClientId",
+                        column: x => x.OAuthClientId,
+                        principalTable: "OAuthClients",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OAuthClients_ClientId",
+                table: "OAuthClients",
+                column: "ClientId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OAuthGrants_ExpiresAt",
+                table: "OAuthGrants",
+                column: "ExpiresAt");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OAuthGrants_OAuthClientId",
+                table: "OAuthGrants",
+                column: "OAuthClientId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OAuthGrants_SessionId",
+                table: "OAuthGrants",
+                column: "SessionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OAuthGrants_TokenHash",
+                table: "OAuthGrants",
+                column: "TokenHash",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OAuthGrants");
+
+            migrationBuilder.DropTable(
+                name: "OAuthClients");
+
+            migrationBuilder.DropColumn(
+                name: "McpOAuthEnabled",
+                table: "Configs");
+        }
+    }
+}

--- a/LifelogBb/Models/Account/LoginModel.cs
+++ b/LifelogBb/Models/Account/LoginModel.cs
@@ -7,5 +7,12 @@ namespace LifelogBb.Models.Account
         [Required]
         [DataType(DataType.Password)]
         public string? Password { get; set; }
+
+        /// <summary>
+        /// Where to go after a successful login. Set by the cookie handler when it intercepts a
+        /// protected page, which is what brings the OAuth consent flow back to /oauth/authorize.
+        /// Only local URLs are honored.
+        /// </summary>
+        public string? ReturnUrl { get; set; }
     }
 }

--- a/LifelogBb/Models/Entities/Config.cs
+++ b/LifelogBb/Models/Entities/Config.cs
@@ -60,6 +60,13 @@ namespace LifelogBb.Models.Entities
         /// </summary>
         public string McpToken { get; set; } = "";
 
+        /// <summary>
+        /// Enables the built-in OAuth 2.1 authorization server for MCP clients that cannot use a
+        /// static token (Claude connectors, Claude Code). Off by default: every OAuth endpoint
+        /// returns 404 and the /mcp 401 does not advertise resource metadata.
+        /// </summary>
+        public bool McpOAuthEnabled { get; set; } = false;
+
         public Config()
         {
             // Default constructor

--- a/LifelogBb/Models/Entities/OAuthClient.cs
+++ b/LifelogBb/Models/Entities/OAuthClient.cs
@@ -1,0 +1,43 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace LifelogBb.Models.Entities
+{
+    /// <summary>
+    /// A public OAuth client created through dynamic client registration (RFC 7591).
+    /// There are no client secrets, every client authenticates with PKCE only.
+    /// </summary>
+    public class OAuthClient : BaseEntity
+    {
+        [Required]
+        [StringLength(64)]
+        public string ClientId { get; set; } = "";
+
+        [Required]
+        [StringLength(200)]
+        public string ClientName { get; set; } = "";
+
+        /// <summary>
+        /// Newline separated redirect URIs. Compared with exact ordinal matching and never queried
+        /// by URI, so a separate table would only add joins.
+        /// </summary>
+        [Required]
+        public string RedirectUris { get; set; } = "";
+
+        [Required]
+        [StringLength(200)]
+        public string Scope { get; set; } = "";
+
+        /// <summary>
+        /// Set the first time the client completes an authorization. Registrations that never get
+        /// used are pruned.
+        /// </summary>
+        public DateTime? LastUsedAt { get; set; }
+
+        [NotMapped]
+        public IReadOnlyList<string> RedirectUriList =>
+            RedirectUris.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        public ICollection<OAuthGrant> Grants { get; set; } = new List<OAuthGrant>();
+    }
+}

--- a/LifelogBb/Models/Entities/OAuthGrant.cs
+++ b/LifelogBb/Models/Entities/OAuthGrant.cs
@@ -1,0 +1,59 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LifelogBb.Models.Entities
+{
+    public enum OAuthGrantType
+    {
+        AuthorizationCode = 0,
+        RefreshToken = 1
+    }
+
+    /// <summary>
+    /// An issued authorization code or refresh token. Both kinds share a table so that revoking a
+    /// whole lineage after a replay is a single delete on <see cref="SessionId"/>.
+    /// </summary>
+    public class OAuthGrant : BaseEntity
+    {
+        public OAuthGrantType GrantType { get; set; }
+
+        public long OAuthClientId { get; set; }
+
+        public OAuthClient? Client { get; set; }
+
+        /// <summary>
+        /// SHA-256 hex of the code or refresh token. The raw value is only ever seen by the client.
+        /// </summary>
+        [Required]
+        [StringLength(64)]
+        public string TokenHash { get; set; } = "";
+
+        /// <summary>
+        /// Chains an authorization code to every refresh token descended from it. Reusing any token
+        /// of the chain revokes all of them.
+        /// </summary>
+        [Required]
+        [StringLength(64)]
+        public string SessionId { get; set; } = "";
+
+        /// <summary>Authorization codes only. The token request has to present the same value.</summary>
+        [StringLength(2000)]
+        public string? RedirectUri { get; set; }
+
+        /// <summary>Authorization codes only. PKCE S256 challenge (RFC 7636).</summary>
+        [StringLength(200)]
+        public string? CodeChallenge { get; set; }
+
+        [Required]
+        [StringLength(200)]
+        public string Scope { get; set; } = "";
+
+        /// <summary>Resource indicator (RFC 8707). Recorded for diagnostics, not enforced.</summary>
+        [StringLength(2000)]
+        public string? Resource { get; set; }
+
+        public DateTime ExpiresAt { get; set; }
+
+        /// <summary>Set when the grant is redeemed. A second attempt is treated as a replay.</summary>
+        public DateTime? ConsumedAt { get; set; }
+    }
+}

--- a/LifelogBb/Models/Home/EditConfigViewModel.cs
+++ b/LifelogBb/Models/Home/EditConfigViewModel.cs
@@ -74,6 +74,9 @@ namespace LifelogBb.Models.Home
         [Display(Name = "MCP Token")]
         public string McpToken { get; set; } = "";
 
+        [Display(Name = "Enable MCP OAuth")]
+        public bool McpOAuthEnabled { get; set; }
+
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
             if (UnitsType == Measurements.Metric)

--- a/LifelogBb/Models/LifelogBbContext.cs
+++ b/LifelogBb/Models/LifelogBbContext.cs
@@ -20,6 +20,8 @@ namespace LifelogBb.Models
         public DbSet<Config> Configs { get; set; } = null!;
         public DbSet<ChatSession> ChatSessions { get; set; } = null!;
         public DbSet<ChatSessionMessage> ChatSessionMessages { get; set; } = null!;
+        public DbSet<OAuthClient> OAuthClients { get; set; } = null!;
+        public DbSet<OAuthGrant> OAuthGrants { get; set; } = null!;
 
         private readonly IConfiguration _configuration;
 
@@ -79,6 +81,7 @@ namespace LifelogBb.Models
             modelBuilder.Entity<Config>().Property(b => b.ChatSystemPrompt).HasDefaultValue("You are a helpful life-tracking assistant for LifelogBB. You can query the user's data (weights, journals, todos, goals, habits, quotes, strength trainings, endurance trainings) using the available tools. Summarize and analyze the data to help the user understand their progress and habits.");
             modelBuilder.Entity<Config>().Property(b => b.ChatMaxToolRoundtrips).HasDefaultValue(10);
             modelBuilder.Entity<Config>().Property(b => b.McpToken).HasDefaultValue("");
+            modelBuilder.Entity<Config>().Property(b => b.McpOAuthEnabled).HasDefaultValue(false);
 
             modelBuilder.Entity<ChatSession>()
                 .HasMany(s => s.Messages)
@@ -87,6 +90,17 @@ namespace LifelogBb.Models
                 .OnDelete(DeleteBehavior.Cascade);
 
             modelBuilder.Entity<Journal>().HasIndex(j => j.Date).IsUnique();
+
+            modelBuilder.Entity<OAuthClient>().HasIndex(c => c.ClientId).IsUnique();
+            modelBuilder.Entity<OAuthGrant>().HasIndex(g => g.TokenHash).IsUnique();
+            modelBuilder.Entity<OAuthGrant>().HasIndex(g => g.SessionId);
+            modelBuilder.Entity<OAuthGrant>().HasIndex(g => g.ExpiresAt);
+
+            modelBuilder.Entity<OAuthClient>()
+                .HasMany(c => c.Grants)
+                .WithOne(g => g.Client)
+                .HasForeignKey(g => g.OAuthClientId)
+                .OnDelete(DeleteBehavior.Cascade);
         }
 
         public void BeginTransaction()

--- a/LifelogBb/Models/OAuth/AuthorizeViewModel.cs
+++ b/LifelogBb/Models/OAuth/AuthorizeViewModel.cs
@@ -1,0 +1,46 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace LifelogBb.Models.OAuth
+{
+    /// <summary>
+    /// The authorization request, bound from the query string on GET and from the consent form on
+    /// POST. ModelBinder only renames the parameters, it does not pin them to a single source, so
+    /// the same model serves both. Everything here is client supplied and is revalidated against
+    /// the database on both requests.
+    /// </summary>
+    public class AuthorizeViewModel
+    {
+        [ModelBinder(Name = "response_type")]
+        public string? ResponseType { get; set; }
+
+        [ModelBinder(Name = "client_id")]
+        public string? ClientId { get; set; }
+
+        [ModelBinder(Name = "redirect_uri")]
+        public string? RedirectUri { get; set; }
+
+        [ModelBinder(Name = "code_challenge")]
+        public string? CodeChallenge { get; set; }
+
+        [ModelBinder(Name = "code_challenge_method")]
+        public string? CodeChallengeMethod { get; set; }
+
+        [ModelBinder(Name = "state")]
+        public string? State { get; set; }
+
+        [ModelBinder(Name = "scope")]
+        public string? Scope { get; set; }
+
+        [ModelBinder(Name = "resource")]
+        public string? Resource { get; set; }
+
+        /// <summary>Display only, always resolved from the database. Never taken from the form.</summary>
+        [BindNever]
+        public string ClientName { get; set; } = "";
+
+        /// <summary>The scope that will actually be granted, which is always the single app scope.</summary>
+        [BindNever]
+        public string GrantedScope { get; set; } = "";
+    }
+}

--- a/LifelogBb/Models/OAuth/ClientRegistrationRequest.cs
+++ b/LifelogBb/Models/OAuth/ClientRegistrationRequest.cs
@@ -1,0 +1,29 @@
+using System.Text.Json.Serialization;
+
+namespace LifelogBb.Models.OAuth
+{
+    /// <summary>
+    /// Dynamic client registration request (RFC 7591). Only the members we act on are declared,
+    /// everything else in the document is ignored as the spec allows.
+    /// </summary>
+    public class ClientRegistrationRequest
+    {
+        [JsonPropertyName("redirect_uris")]
+        public string[]? RedirectUris { get; set; }
+
+        [JsonPropertyName("client_name")]
+        public string? ClientName { get; set; }
+
+        [JsonPropertyName("grant_types")]
+        public string[]? GrantTypes { get; set; }
+
+        [JsonPropertyName("response_types")]
+        public string[]? ResponseTypes { get; set; }
+
+        [JsonPropertyName("scope")]
+        public string? Scope { get; set; }
+
+        [JsonPropertyName("token_endpoint_auth_method")]
+        public string? TokenEndpointAuthMethod { get; set; }
+    }
+}

--- a/LifelogBb/Models/OAuth/OAuthErrorViewModel.cs
+++ b/LifelogBb/Models/OAuth/OAuthErrorViewModel.cs
@@ -1,0 +1,13 @@
+namespace LifelogBb.Models.OAuth
+{
+    /// <summary>
+    /// Rendered for the authorization errors that must not be redirected back to the client,
+    /// because an unverified redirect URI cannot be trusted with the error.
+    /// </summary>
+    public class OAuthErrorViewModel
+    {
+        public string Error { get; set; } = "";
+
+        public string Description { get; set; } = "";
+    }
+}

--- a/LifelogBb/Models/OAuth/TokenRequest.cs
+++ b/LifelogBb/Models/OAuth/TokenRequest.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace LifelogBb.Models.OAuth
+{
+    /// <summary>
+    /// Form encoded token request. There is no client authentication, clients are public and prove
+    /// possession with PKCE.
+    /// </summary>
+    public class TokenRequest
+    {
+        [FromForm(Name = "grant_type")]
+        public string? GrantType { get; set; }
+
+        [FromForm(Name = "client_id")]
+        public string? ClientId { get; set; }
+
+        [FromForm(Name = "code")]
+        public string? Code { get; set; }
+
+        [FromForm(Name = "redirect_uri")]
+        public string? RedirectUri { get; set; }
+
+        [FromForm(Name = "code_verifier")]
+        public string? CodeVerifier { get; set; }
+
+        [FromForm(Name = "refresh_token")]
+        public string? RefreshToken { get; set; }
+
+        [FromForm(Name = "resource")]
+        public string? Resource { get; set; }
+    }
+}

--- a/LifelogBb/Program.cs
+++ b/LifelogBb/Program.cs
@@ -164,9 +164,10 @@ namespace LifelogBb
             })
             .AddScheme<AuthenticationSchemeOptions, McpTokenAuthenticationHandler>(
                 McpTokenDefaults.AuthenticationScheme, McpTokenDefaults.DisplayName, options => { })
-            // No AddMcp() here. It only serves OAuth resource metadata discovery, which needs an OAuth
-            // server we do not have. Its handler intercepts /.well-known/oauth-protected-resource and
-            // throws when ResourceMetadata is unset. MCP clients authenticate with the MCP token or a JWT.
+            // No AddMcp() here. Its handler intercepts /.well-known/oauth-protected-resource and serves
+            // a single static document. OAuthController serves both RFC 9728 path variants itself and
+            // hides them while Config.McpOAuthEnabled is off, and McpTokenAuthenticationHandler adds the
+            // matching resource_metadata challenge. MCP clients authenticate with OAuth, the MCP token or a JWT.
             .AddPolicyScheme("JWT_OR_COOKIE", "JWT_OR_COOKIE", options =>
             {
                 options.ForwardDefaultSelector = context =>

--- a/LifelogBb/Utilities/LogSanitizer.cs
+++ b/LifelogBb/Utilities/LogSanitizer.cs
@@ -1,0 +1,28 @@
+using System.Text.RegularExpressions;
+
+namespace LifelogBb.Utilities;
+
+/// <summary>
+/// Strips control characters out of untrusted values before they reach the log.
+/// Without this, a value containing a newline can forge whole log lines, for example an OAuth
+/// client registering itself under the name "ok\nRegistered OAuth client admin".
+/// </summary>
+public static partial class LogSanitizer
+{
+    private const int DefaultMaxLength = 200;
+
+    /// <summary>Unicode "other" category: control, format and unassigned characters.</summary>
+    [GeneratedRegex(@"\p{C}")]
+    private static partial Regex ControlCharacters();
+
+    public static string ForLog(string? value, int maxLength = DefaultMaxLength)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return "";
+        }
+
+        var sanitized = ControlCharacters().Replace(value, "");
+        return sanitized.Length <= maxLength ? sanitized : string.Concat(sanitized.AsSpan(0, maxLength), "...");
+    }
+}

--- a/LifelogBb/Utilities/McpTokenAuthenticationHandler.cs
+++ b/LifelogBb/Utilities/McpTokenAuthenticationHandler.cs
@@ -79,12 +79,29 @@ public class McpTokenAuthenticationHandler : AuthenticationHandler<Authenticatio
         return await Context.AuthenticateAsync(JwtBearerDefaults.AuthenticationScheme);
     }
 
-    protected override Task HandleChallengeAsync(AuthenticationProperties properties)
+    protected override async Task HandleChallengeAsync(AuthenticationProperties properties)
     {
         // Never redirect to the cookie login page, MCP clients need a plain 401.
         Response.StatusCode = StatusCodes.Status401Unauthorized;
-        Response.Headers[HeaderNames.WWWAuthenticate] = "Bearer";
-        return Task.CompletedTask;
+
+        var challenge = "Bearer";
+        try
+        {
+            // Read only, see HandleAuthenticateAsync. This is what points an OAuth capable client at
+            // the discovery documents (RFC 9728), so it stays quiet while OAuth is disabled.
+            if (await OAuthSettings.IsEnabledAsync(_context, Context.RequestAborted))
+            {
+                var baseUrl = PublicUrl.GetBaseUrl(Request);
+                challenge = $"Bearer resource_metadata=\"{baseUrl}{OAuthDefaults.ProtectedResourceMetadataPath}\"";
+            }
+        }
+        catch (Exception ex)
+        {
+            // A failed lookup, for example on an aborted request, must still produce a valid 401.
+            Logger.LogWarning(ex, "Could not read the MCP OAuth setting for the challenge header.");
+        }
+
+        Response.Headers[HeaderNames.WWWAuthenticate] = challenge;
     }
 
     protected override Task HandleForbiddenAsync(AuthenticationProperties properties)

--- a/LifelogBb/Utilities/OAuthCrypto.cs
+++ b/LifelogBb/Utilities/OAuthCrypto.cs
@@ -1,0 +1,54 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace LifelogBb.Utilities;
+
+/// <summary>
+/// Secret generation, storage hashing and PKCE verification for the OAuth server.
+/// </summary>
+public static class OAuthCrypto
+{
+    /// <summary>Creates a base64url encoded random secret. 32 bytes is 256 bits of entropy.</summary>
+    public static string NewSecret(int byteCount = 32) => Base64Url(RandomNumberGenerator.GetBytes(byteCount));
+
+    /// <summary>
+    /// Hash for the stored copy of a code or refresh token. These are high entropy random values,
+    /// so a preimage resistant hash is enough. A password hash would only make the indexed lookup
+    /// impossible without buying any additional protection.
+    /// </summary>
+    public static string Sha256Hex(string value) =>
+        Convert.ToHexStringLower(SHA256.HashData(Encoding.ASCII.GetBytes(value)));
+
+    /// <summary>
+    /// RFC 7636 S256: BASE64URL(SHA256(ASCII(code_verifier))) has to equal the stored challenge.
+    /// </summary>
+    public static bool VerifyPkceS256(string codeVerifier, string storedChallenge)
+    {
+        var computed = Base64Url(SHA256.HashData(Encoding.ASCII.GetBytes(codeVerifier)));
+        return CryptographicOperations.FixedTimeEquals(
+            Encoding.ASCII.GetBytes(computed), Encoding.ASCII.GetBytes(storedChallenge));
+    }
+
+    /// <summary>RFC 7636 unreserved character set for verifiers and challenges.</summary>
+    public static bool IsValidPkceValue(string? value)
+    {
+        if (value is null || value.Length < OAuthDefaults.MinPkceLength || value.Length > OAuthDefaults.MaxPkceLength)
+        {
+            return false;
+        }
+
+        foreach (var c in value)
+        {
+            var allowed = c is >= 'A' and <= 'Z' or >= 'a' and <= 'z' or >= '0' and <= '9' or '-' or '.' or '_' or '~';
+            if (!allowed)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static string Base64Url(byte[] bytes) =>
+        Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+}

--- a/LifelogBb/Utilities/OAuthDefaults.cs
+++ b/LifelogBb/Utilities/OAuthDefaults.cs
@@ -1,0 +1,40 @@
+namespace LifelogBb.Utilities;
+
+/// <summary>
+/// Constants for the built-in OAuth 2.1 authorization server used by MCP clients.
+/// </summary>
+public static class OAuthDefaults
+{
+    /// <summary>The only scope. It always grants full access, mirroring the single user model.</summary>
+    public const string Scope = "lifelogbb";
+
+    /// <summary>Path of the protected resource the tokens are meant for.</summary>
+    public const string ResourcePath = "/mcp";
+
+    public const string ProtectedResourceMetadataPath = "/.well-known/oauth-protected-resource";
+
+    public const string AuthorizationServerMetadataPath = "/.well-known/oauth-authorization-server";
+
+    /// <summary>Authorization codes are exchanged immediately, so this can be short.</summary>
+    public static readonly TimeSpan CodeLifetime = TimeSpan.FromSeconds(60);
+
+    public static readonly TimeSpan RefreshLifetime = TimeSpan.FromDays(30);
+
+    /// <summary>Registrations that never completed a flow are pruned after this long.</summary>
+    public static readonly TimeSpan UnusedClientLifetime = TimeSpan.FromDays(1);
+
+    /// <summary>Expired grants are deleted this long after they expired.</summary>
+    public static readonly TimeSpan ExpiredGrantRetention = TimeSpan.FromDays(1);
+
+    public static readonly TimeSpan SweepInterval = TimeSpan.FromMinutes(10);
+
+    public const int MaxClients = 100;
+    public const int MaxRedirectUrisPerClient = 10;
+    public const int MaxUriLength = 2000;
+    public const int MaxStateLength = 512;
+    public const int MaxClientNameLength = 200;
+
+    /// <summary>RFC 7636 bounds for both the code verifier and the code challenge.</summary>
+    public const int MinPkceLength = 43;
+    public const int MaxPkceLength = 128;
+}

--- a/LifelogBb/Utilities/OAuthSettings.cs
+++ b/LifelogBb/Utilities/OAuthSettings.cs
@@ -1,0 +1,18 @@
+using LifelogBb.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace LifelogBb.Utilities;
+
+/// <summary>
+/// Reads the OAuth toggle from the app config row.
+/// </summary>
+public static class OAuthSettings
+{
+    /// <summary>
+    /// Read only. Config.GetConfig would insert and save a row as a side effect, which must not
+    /// happen on the anonymous OAuth endpoints. No row yet means no toggle, which is the correct
+    /// "disabled" default.
+    /// </summary>
+    public static Task<bool> IsEnabledAsync(LifelogBbContext context, CancellationToken cancellationToken = default) =>
+        context.Configs.AsNoTracking().Select(c => c.McpOAuthEnabled).FirstOrDefaultAsync(cancellationToken);
+}

--- a/LifelogBb/Utilities/PublicUrl.cs
+++ b/LifelogBb/Utilities/PublicUrl.cs
@@ -1,0 +1,26 @@
+namespace LifelogBb.Utilities;
+
+/// <summary>
+/// Builds the externally visible base URL. OAuth metadata has to advertise the URL the client
+/// actually used, not the one Kestrel is bound to.
+/// </summary>
+public static class PublicUrl
+{
+    /// <summary>
+    /// Escape hatch for reverse proxies that do not forward the scheme or host correctly.
+    /// Normally unset, because app.UseForwardedHeaders() already fixes both.
+    /// </summary>
+    public const string OverrideConfigKey = "Authentication:OAuth:PublicBaseUrl";
+
+    /// <summary>Returns the base URL without a trailing slash, e.g. "https://lifelog.example".</summary>
+    public static string GetBaseUrl(HttpRequest request, IConfiguration? configuration = null)
+    {
+        var configured = configuration?[OverrideConfigKey];
+        if (!string.IsNullOrWhiteSpace(configured))
+        {
+            return configured.TrimEnd('/');
+        }
+
+        return $"{request.Scheme}://{request.Host}{request.PathBase}".TrimEnd('/');
+    }
+}

--- a/LifelogBb/Utilities/RequireOAuthEnabledAttribute.cs
+++ b/LifelogBb/Utilities/RequireOAuthEnabledAttribute.cs
@@ -1,0 +1,27 @@
+using LifelogBb.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace LifelogBb.Utilities;
+
+/// <summary>
+/// Hides the whole OAuth surface while <see cref="Models.Entities.Config.McpOAuthEnabled"/> is off.
+/// A 404 keeps a disabled instance indistinguishable from one that never had OAuth.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public sealed class RequireOAuthEnabledAttribute : Attribute, IAsyncResourceFilter
+{
+    public async Task OnResourceExecutionAsync(ResourceExecutingContext context, ResourceExecutionDelegate next)
+    {
+        // Resolved per request instead of through the constructor so the attribute needs no DI registration.
+        var dbContext = context.HttpContext.RequestServices.GetRequiredService<LifelogBbContext>();
+
+        if (!await OAuthSettings.IsEnabledAsync(dbContext, context.HttpContext.RequestAborted))
+        {
+            context.Result = new NotFoundResult();
+            return;
+        }
+
+        await next();
+    }
+}

--- a/LifelogBb/Views/Account/Login.cshtml
+++ b/LifelogBb/Views/Account/Login.cshtml
@@ -10,6 +10,8 @@
             <div class="card-body">
                 <h2 class="h2 text-center mb-4">Login to your account</h2>
                 <form asp-action="Login">
+                    @* asp-action drops the query string, so the return URL has to travel in the body. *@
+                    <input type="hidden" asp-for="ReturnUrl" />
                     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
                     <div class="mb-2">
                         <label class="form-label">

--- a/LifelogBb/Views/Home/Config.cshtml
+++ b/LifelogBb/Views/Home/Config.cshtml
@@ -165,7 +165,15 @@
                     <div class="card-body">
                         <div class="alert alert-info" role="alert">
                             <h4 class="alert-title">MCP Server</h4>
-                            <div class="text-secondary">LifelogBB includes a built-in <strong>Model Context Protocol (MCP)</strong> server at <code>/mcp</code>. Connect AI assistants (e.g. Claude Desktop, GitHub Copilot, Cursor) by providing your instance URL and the MCP token below as an <code>Authorization: Bearer</code> header. Alternatively use a short lived JWT token obtained from <a href="/Swagger/" target="_blank">Swagger UI</a> via <code>POST /api/authentication</code>.</div>
+                            <div class="text-secondary">LifelogBB includes a built-in <strong>Model Context Protocol (MCP)</strong> server at <code>@($"{Context.Request.Scheme}://{Context.Request.Host}/mcp")</code>. Connect AI assistants (e.g. Claude Desktop, GitHub Copilot, Cursor) by providing your instance URL and the MCP token below as an <code>Authorization: Bearer</code> header. Alternatively use a short lived JWT token obtained from <a href="/Swagger/" target="_blank">Swagger UI</a> via <code>POST /api/authentication</code>, or enable OAuth below for clients that cannot use a static token.</div>
+                        </div>
+                        <div class="form-group mb-3">
+                            <label class="form-check form-switch">
+                                <input asp-for="McpOAuthEnabled" class="form-check-input" type="checkbox" />
+                                <span class="form-check-label">@Html.DisplayNameFor(m => m.McpOAuthEnabled)</span>
+                            </label>
+                            <div class="form-hint">Runs a built-in OAuth 2.1 authorization server so clients like Claude can sign in with your normal password instead of a static token. While disabled all OAuth endpoints return <code>404</code>. Requires a publicly reachable HTTPS URL for hosted clients.</div>
+                            <span asp-validation-for="McpOAuthEnabled" class="text-danger"></span>
                         </div>
                         <div class="form-group mb-3">
                             <label asp-for="McpToken" class="control-label mb-1"></label>

--- a/LifelogBb/Views/OAuth/Authorize.cshtml
+++ b/LifelogBb/Views/OAuth/Authorize.cshtml
@@ -1,0 +1,55 @@
+@model LifelogBb.Models.OAuth.AuthorizeViewModel
+
+@{
+    ViewData["Title"] = "Authorize access";
+}
+
+<div class="page page-center">
+    <div class="container container-tight py-4">
+        <div class="card card-md">
+            <div class="card-body">
+                <h2 class="h2 text-center mb-4">Authorize access</h2>
+                <p class="text-secondary">
+                    <strong>@Model.ClientName</strong> wants to connect to your LifelogBB instance.
+                </p>
+                <div class="alert alert-warning" role="alert">
+                    <h4 class="alert-title">This grants full access</h4>
+                    <div class="text-secondary">
+                        The application will be able to read and create all of your data: weights, journals,
+                        todos, goals, habits, quotes and trainings.
+                    </div>
+                </div>
+                <dl class="row">
+                    <dt class="col-4">Scope</dt>
+                    <dd class="col-8"><code>@Model.GrantedScope</code></dd>
+                    <dt class="col-4">Redirect to</dt>
+                    <dd class="col-8 text-break"><code>@Model.RedirectUri</code></dd>
+                </dl>
+                <p class="text-secondary">
+                    Only approve this if you started the connection yourself and recognise the address above.
+                </p>
+                @* Every value is posted back and revalidated against the database, nothing is trusted. *@
+                <form asp-action="Authorize" method="post">
+                    <input type="hidden" name="response_type" value="@Model.ResponseType" />
+                    <input type="hidden" name="client_id" value="@Model.ClientId" />
+                    <input type="hidden" name="redirect_uri" value="@Model.RedirectUri" />
+                    <input type="hidden" name="code_challenge" value="@Model.CodeChallenge" />
+                    <input type="hidden" name="code_challenge_method" value="@Model.CodeChallengeMethod" />
+                    <input type="hidden" name="state" value="@Model.State" />
+                    <input type="hidden" name="scope" value="@Model.Scope" />
+                    <input type="hidden" name="resource" value="@Model.Resource" />
+                    <div class="form-footer">
+                        <div class="d-flex">
+                            <button type="submit" name="decision" value="deny" class="btn btn-secondary">
+                                <i class="fas fa-ban icon"></i>Deny
+                            </button>
+                            <button type="submit" name="decision" value="approve" class="btn btn-primary ms-auto">
+                                <i class="fas fa-check icon"></i>Approve
+                            </button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/LifelogBb/Views/OAuth/Error.cshtml
+++ b/LifelogBb/Views/OAuth/Error.cshtml
@@ -1,0 +1,28 @@
+@model LifelogBb.Models.OAuth.OAuthErrorViewModel
+
+@{
+    ViewData["Title"] = "Authorization failed";
+}
+
+<div class="page page-center">
+    <div class="container container-tight py-4">
+        <div class="card card-md">
+            <div class="card-body">
+                <h2 class="h2 text-center mb-4">Authorization failed</h2>
+                <div class="alert alert-danger" role="alert">
+                    <h4 class="alert-title">@Model.Error</h4>
+                    <div class="text-secondary">@Model.Description</div>
+                </div>
+                @* The redirect target of a failed request is unverified, so nothing links back to it. *@
+                <p class="text-secondary">
+                    Nothing was shared. Start the connection again from the application you were using.
+                </p>
+                <div class="form-footer">
+                    <a class="btn btn-secondary w-100" asp-controller="Home" asp-action="Index">
+                        <i class="fas fa-arrow-circle-left icon"></i>Back to LifelogBB
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ dotnet watch
 All migrations are bundled in the `efbundle` file. Run it with the `--connection` argument.
 For Windows the `efbundle` is called `efbundle.exe`.
 
+Regenerate the bundle with `dotnet ef migrations bundle` whenever a migration is added, otherwise a deployment misses the new tables.
+
 ```sh
 # Install dotnet-ef
 dotnet tool install --global dotnet-ef | echo "already installed"
@@ -209,10 +211,13 @@ WantedBy=multi-user.target
 
 LifelogBB exposes a built-in **Model Context Protocol (MCP)** server that lets AI assistants (e.g. Claude, GitHub Copilot, Cursor) read and interact with your life-log data directly.
 
-The MCP endpoint is available at `/mcp` and accepts a **Bearer token** in the `Authorization` header. Two kinds of token work:
+The MCP endpoint is available at `/mcp` and accepts a **Bearer token** in the `Authorization` header. Three ways to get one, depending on what the client supports:
 
-* **MCP token (recommended).** Set a long random value under *Config → Chat / AI → MCP Token*. It does not expire, so MCP clients keep working without re-authenticating. Leave the field empty to disable this and allow JWT tokens only.
-* **JWT token.** Generate one via the Swagger UI (`/Swagger/`) using `POST /api/authentication` with your configured password. It expires after `Authentication:JwtToken:TokenTimeoutMinutes` (60 minutes by default).
+* **MCP token** — for clients you configure by hand with a config file or a header field (Claude Desktop, Copilot, Cursor). Set a long random value under *Config → Chat / AI → MCP Token*. It does not expire, so the client keeps working without re-authenticating. Leave the field empty to reject static tokens and allow the other two only.
+* **OAuth** — for clients that sign in themselves and offer no field to paste a token into, such as claude.ai connectors and Claude Code. Off by default, see [OAuth](#oauth-claude-connectors-and-claude-code) below.
+* **JWT token** — for scripts and one-off testing. Generate one via the Swagger UI (`/Swagger/`) using `POST /api/authentication` with your configured password. It expires after `Authentication:JwtToken:TokenTimeoutMinutes` (60 minutes by default).
+
+All three work at the same time and none of them disables the others. The MCP token is checked first on `/mcp`; anything else falls through to JWT validation, which is also what OAuth access tokens are.
 
 ### Example MCP configuration (Claude Desktop / mcp.json)
 
@@ -232,7 +237,29 @@ The MCP endpoint is available at `/mcp` and accepts a **Bearer token** in the `A
 
 Replace `https://your-lifelogbb-host` with the URL of your LifelogBB instance and `<your-mcp-token>` with the token from the config page.
 
-The MCP token grants full read and write access to all of your life-log data and never expires. Only use it over HTTPS and treat it like a password.
+The MCP token grants full read and write access to all of your life-log data and never expires. Only use it over HTTPS and treat it like a password. Every client presents the same value, so there is no way to cut off one of them: replacing the token in the config disconnects all of them at once. OAuth is the better choice if that matters, since each client gets its own refresh token and deleting its row from `OAuthClients` stops only that client from renewing.
+
+### OAuth (Claude connectors and Claude Code)
+
+Claude connects to MCP servers with OAuth and offers no field for a static token, so LifelogBB ships a small built-in OAuth 2.1 authorization server. It is **off by default**. Enable it under *Config → Chat / AI → Enable MCP OAuth*; while it is off, every OAuth endpoint returns `404` and the `/mcp` challenge does not advertise it.
+
+Once enabled, point the client at your instance and it discovers the rest on its own:
+
+```sh
+claude mcp add --transport http lifelogbb https://your-lifelogbb-host/mcp
+```
+
+For a claude.ai custom connector use *Settings → Connectors → Add custom connector* with the same `/mcp` URL. Anthropic's servers perform the discovery and token calls, so the instance needs a **publicly reachable HTTPS URL with a valid certificate** — `localhost` and self-signed certificates will not work there.
+
+The client registers itself, sends you to the normal LifelogBB login, and shows a consent screen before any token is issued. Nothing about your password leaves the instance. The endpoints involved are `/.well-known/oauth-protected-resource`, `/.well-known/oauth-authorization-server`, `/oauth/register`, `/oauth/authorize` and `/oauth/token`.
+
+Deliberate limitations of this minimal implementation:
+
+* Access tokens are the same JWTs `POST /api/authentication` issues, so they are also valid on the REST API and Swagger. With a single account this grants nothing extra, but tokens are not bound to the `/mcp` resource (RFC 8707).
+* There is a single scope that always grants full read and write access. Requested scopes are ignored.
+* Clients are public, there are no client secrets and no client configuration endpoint (RFC 7592). Registered clients are managed by editing the database.
+* There is no token introspection or revocation. Access tokens stay valid until they expire; turning the toggle off stops new ones but does not invalidate outstanding ones. Rotating `Authentication:JwtToken:SigningKey` invalidates everything immediately.
+* There is no rate limiting. If the instance is exposed to the internet, add something like nginx `limit_req` in front of `/oauth/`.
 
 ## Development
 


### PR DESCRIPTION
## Why

Claude connects to MCP servers over OAuth and offers no field to paste a static token into, so the long lived `Config.McpToken` added in #19 cannot serve it. `AddMcp()` was removed in #20 because the SDK handler only serves resource metadata discovery and threw on `/.well-known/oauth-protected-resource` with no OAuth server behind it. This adds that server.

## What

A minimal hand-rolled authorization server in `Controllers/OAuthController.cs`, no new NuGet dependency:

- Protected resource metadata (RFC 9728) and authorization server metadata (RFC 8414), each served on both the bare and the `/mcp` suffixed path variant clients probe
- Dynamic client registration (RFC 7591), public clients only
- Authorization code flow with mandatory PKCE S256, plus refresh tokens with rotation
- `McpTokenAuthenticationHandler` now adds `resource_metadata` to the `/mcp` 401 challenge, which is what points a client at discovery in the first place

The resource owner is the single app password, so `/oauth/authorize` reuses the normal cookie login and adds a consent screen. Access tokens are the same JWTs `POST /api/authentication` issues, so the existing JWT fallback accepts them and **the `/mcp` authentication itself is unchanged**. The static MCP token keeps working alongside OAuth.

Everything sits behind a new `Config.McpOAuthEnabled` toggle that **defaults to off**: while off, every OAuth endpoint returns `404` and the `/mcp` challenge stays silent about metadata. Existing installs gain no new attack surface until the switch is flipped.

## Reviewer notes

Two things worth a look:

- **The cookie check on `/oauth/authorize` is inside the action, not an `[Authorize]` attribute.** Attribute metadata is handled by `AuthorizationMiddleware`, which runs before any MVC filter, so a disabled instance answered with a 302 to the login page instead of 404 and leaked that the endpoint exists. Doing it inline also lets us authenticate the cookie scheme *explicitly*, which stops a leaked bearer token from approving a fresh grant for itself.
- **`AccountController.Login` now honours `ReturnUrl`** (validated with `Url.IsLocalUrl`). It previously always redirected to the dashboard, which silently dropped the authorization request mid-flow. This also fixes the pre-existing annoyance where any logged-out deep link dumped you on the dashboard after signing in.

`AddMcp()` is still deliberately not registered — its handler would hijack `/.well-known/oauth-protected-resource` and serve one static document, and we need both path variants plus the 404-when-disabled behaviour. The stale comment in `Program.cs` is updated.

## Deliberate limitations (documented in the README)

- Access tokens keep the app-wide JWT audience rather than being bound to `/mcp` (RFC 8707), so they are also valid on `/api/*` and Swagger. With one account this grants nothing extra.
- Single scope, always full access. No client secrets, no RFC 7592 client configuration endpoint. No introspection or revocation — rotating `Authentication:JwtToken:SigningKey` is the kill switch. No rate limiting; use nginx `limit_req` if internet-facing.

## Testing

Verified locally against a throwaway database, toggling off to on and back:

- All endpoints `404` while disabled; all four discovery documents correct when enabled (`issuer` without trailing slash, `code_challenge_methods_supported: ["S256"]` present)
- Challenge header gains and loses `resource_metadata` with the toggle
- Registration accepts https and `http` loopback, rejects plain http, fragments and `client_secret_post`; re-registering reuses the row
- Wrong PKCE verifier fails **and burns the code**; replay, expiry, `redirect_uri` mismatch and `client_id` mismatch all rejected
- Refresh rotates; reusing an old refresh token revokes the whole chain including the newly issued one
- `tools/list` over `/mcp` with an OAuth access token returns all 16 tools

**Not verified — needs a signed-in browser:** the Config page checkbox binding, the consent screen itself, and the login `ReturnUrl` redirect landing back on `/oauth/authorize`. The inputs to that last one were checked mechanically (the 302 carries the full authorize URL and the form round-trips it in a hidden field); only the final `LocalRedirect` is unexercised. Real Claude Code / claude.ai connector flows also still need a public HTTPS deployment.

A migration is included, so `dotnet ef migrations bundle` needs re-running before deploying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)