### PR TITLE
Add Update and Delete MCP tools plus sort and limit for queries

### DIFF
--- a/LifelogBb/ApiControllers/BaseCRUDController.cs
+++ b/LifelogBb/ApiControllers/BaseCRUDController.cs
@@ -20,13 +20,13 @@ namespace LifelogBb.ApiControllers
 
         // GET: api/[controller]
         [HttpGet]
-        public virtual async Task<ActionResult<IEnumerable<OUTP>>> GetAll([FromQuery] string? filter)
+        public virtual async Task<ActionResult<IEnumerable<OUTP>>> GetAll([FromQuery] string? filter, [FromQuery] string? sort, [FromQuery] int? limit)
         {
-            if (!string.IsNullOrWhiteSpace(filter))
+            if (!string.IsNullOrWhiteSpace(filter) || !string.IsNullOrWhiteSpace(sort) || limit.HasValue)
             {
                 try
                 {
-                    return await _service.GetAll(filter);
+                    return await _service.GetAll(filter, sort, limit);
                 }
                 catch (ArgumentException e)
                 {

--- a/LifelogBb/ApiServices/BaseCRUDService.cs
+++ b/LifelogBb/ApiServices/BaseCRUDService.cs
@@ -11,7 +11,7 @@ namespace LifelogBb.ApiServices
     {
         protected readonly IRepository<TEntity> _repository;
         protected readonly IMapper _mapper;
-        
+
         public BaseCRUDService(IRepository<TEntity> repository, IMapper mapper)
         {
             _repository = repository;
@@ -24,11 +24,43 @@ namespace LifelogBb.ApiServices
             return _mapper.Map<List<OUTP>>(entities);
         }
 
-        public virtual async Task<ActionResult<IEnumerable<OUTP>>> GetAll(string? filterJson)
+        /// <summary>
+        /// Sort order applied when the caller does not ask for one. Entities with their own date
+        /// field override this so that "newest" means the same here as it does in the UI.
+        /// </summary>
+        protected virtual string DefaultSortOrder => $"{nameof(BaseEntity.CreatedAt)}_desc";
+
+        /// <summary>
+        /// Filters, sorts and limits in one query. Results are always ordered so that a limit is
+        /// deterministic; without an explicit sortOrder the newest entries come first.
+        /// </summary>
+        public virtual async Task<ActionResult<IEnumerable<OUTP>>> GetAll(string? filterJson, string? sortOrder = null, int? limit = null)
         {
-            var query = _repository.Query.FilterByGroup<TEntity>(filterJson, throwOnInvalidFilter: true);
+            EnsureSortableField(sortOrder);
+
+            IQueryable<TEntity> query = _repository.Query
+                .FilterByGroup<TEntity>(filterJson, throwOnInvalidFilter: true)
+                .SortByName(sortOrder ?? string.Empty, DefaultSortOrder);
+
+            if (limit.HasValue)
+                query = query.Take(Math.Max(1, limit.Value));
+
             var entities = await query.ToListAsync();
             return _mapper.Map<List<OUTP>>(entities);
+        }
+
+        /// <summary>
+        /// SortByName silently falls back to its default for unknown fields. Callers of the API and
+        /// the MCP tools get a clear error instead, so a typo does not look like a successful sort.
+        /// </summary>
+        private static void EnsureSortableField(string? sortOrder)
+        {
+            if (string.IsNullOrWhiteSpace(sortOrder))
+                return;
+
+            var field = sortOrder.EndsWith("_desc") ? sortOrder[..^5] : sortOrder;
+            if (typeof(TEntity).GetProperty(field) == null)
+                throw new ArgumentException($"Unknown sort field '{field}'.");
         }
 
         public virtual async Task<OUTP> GetById(long id)

--- a/LifelogBb/ApiServices/BaseCRUDService.cs
+++ b/LifelogBb/ApiServices/BaseCRUDService.cs
@@ -38,12 +38,15 @@ namespace LifelogBb.ApiServices
         {
             EnsureSortableField(sortOrder);
 
+            if (limit is < 1)
+                throw new ArgumentException($"Limit must be at least 1 but was {limit}.");
+
             IQueryable<TEntity> query = _repository.Query
                 .FilterByGroup<TEntity>(filterJson, throwOnInvalidFilter: true)
                 .SortByName(sortOrder ?? string.Empty, DefaultSortOrder);
 
             if (limit.HasValue)
-                query = query.Take(Math.Max(1, limit.Value));
+                query = query.Take(limit.Value);
 
             var entities = await query.ToListAsync();
             return _mapper.Map<List<OUTP>>(entities);
@@ -52,14 +55,18 @@ namespace LifelogBb.ApiServices
         /// <summary>
         /// SortByName silently falls back to its default for unknown fields. Callers of the API and
         /// the MCP tools get a clear error instead, so a typo does not look like a successful sort.
+        /// Checked against the EF model rather than the CLR type, because computed properties such
+        /// as Weight.BmiOverweight are not mapped to a column and would only fail once EF tries to
+        /// translate the query.
         /// </summary>
-        private static void EnsureSortableField(string? sortOrder)
+        private void EnsureSortableField(string? sortOrder)
         {
             if (string.IsNullOrWhiteSpace(sortOrder))
                 return;
 
             var field = sortOrder.EndsWith("_desc") ? sortOrder[..^5] : sortOrder;
-            if (typeof(TEntity).GetProperty(field) == null)
+            var entityType = _repository.Context.Model.FindEntityType(typeof(TEntity));
+            if (entityType?.FindProperty(field) == null)
                 throw new ArgumentException($"Unknown sort field '{field}'.");
         }
 

--- a/LifelogBb/ApiServices/BaseCRUDService.cs
+++ b/LifelogBb/ApiServices/BaseCRUDService.cs
@@ -36,7 +36,7 @@ namespace LifelogBb.ApiServices
         /// </summary>
         public virtual async Task<ActionResult<IEnumerable<OUTP>>> GetAll(string? filterJson, string? sortOrder = null, int? limit = null)
         {
-            EnsureSortableField(sortOrder);
+            sortOrder = EnsureSortableField(sortOrder);
 
             if (limit is < 1)
                 throw new ArgumentException($"Limit must be at least 1 but was {limit}.");
@@ -58,16 +58,28 @@ namespace LifelogBb.ApiServices
         /// Checked against the EF model rather than the CLR type, because computed properties such
         /// as Weight.BmiOverweight are not mapped to a column and would only fail once EF tries to
         /// translate the query.
+        /// Returns the sortOrder with the field's canonical (correctly-cased) name, since SortByName
+        /// resolves properties via case-sensitive reflection and would otherwise silently fall back
+        /// to the default sort for a field that only differs by case (e.g. "title" vs "Title").
         /// </summary>
-        private void EnsureSortableField(string? sortOrder)
+        private string? EnsureSortableField(string? sortOrder)
         {
             if (string.IsNullOrWhiteSpace(sortOrder))
-                return;
+                return sortOrder;
 
-            var field = sortOrder.EndsWith("_desc") ? sortOrder[..^5] : sortOrder;
+            var isDescending = sortOrder.EndsWith("_desc");
+            var field = isDescending ? sortOrder[..^5] : sortOrder;
             var entityType = _repository.Context.Model.FindEntityType(typeof(TEntity));
-            if (entityType?.FindProperty(field) == null)
-                throw new ArgumentException($"Unknown sort field '{field}'.");
+            var property = entityType?.GetProperties()
+                .FirstOrDefault(p => string.Equals(p.Name, field, StringComparison.OrdinalIgnoreCase));
+            if (property == null)
+            {
+                var validFields = entityType?.GetProperties().Select(p => p.Name) ?? Enumerable.Empty<string>();
+                throw new ArgumentException(
+                    $"Unknown sort field '{field}'. Valid fields are: {string.Join(", ", validFields)}.");
+            }
+
+            return isDescending ? $"{property.Name}_desc" : property.Name;
         }
 
         public virtual async Task<OUTP> GetById(long id)

--- a/LifelogBb/ApiServices/JournalsService.cs
+++ b/LifelogBb/ApiServices/JournalsService.cs
@@ -10,5 +10,9 @@ namespace LifelogBb.ApiServices
         public JournalsService(IRepository<Journal> repository, IMapper mapper) : base(repository, mapper)
         {
         }
+
+        // A journal carries the day it is about, which can differ from the day it was written.
+        // Matches the sort order of the journal list in the UI.
+        protected override string DefaultSortOrder => $"{nameof(Journal.Date)}_desc";
     }
 }

--- a/LifelogBb/Interfaces/IBaseCRUDService.cs
+++ b/LifelogBb/Interfaces/IBaseCRUDService.cs
@@ -5,7 +5,7 @@ namespace LifelogBb.Interfaces
     public interface IBaseCRUDService<INP, OUTP>
     {
         public Task<ActionResult<IEnumerable<OUTP>>> GetAll();
-        public Task<ActionResult<IEnumerable<OUTP>>> GetAll(string? filterJson);
+        public Task<ActionResult<IEnumerable<OUTP>>> GetAll(string? filterJson, string? sortOrder = null, int? limit = null);
         public Task<OUTP> GetById(long id);
         public Task<OUTP> Create(INP inputModel);
         public Task<OUTP> Update(long id, INP inputModel);

--- a/LifelogBb/McpControllers/BaseTool.cs
+++ b/LifelogBb/McpControllers/BaseTool.cs
@@ -15,11 +15,9 @@ namespace LifelogBb.McpControllers
             _service = service;
         }
 
-        protected async Task<IEnumerable<OUTP>> GetAllFiltered(string? filter)
+        protected async Task<IEnumerable<OUTP>> GetAllFiltered(string? filter, string? sort, int? limit)
         {
-            var result = filter != null
-                ? await _service.GetAll(filter)
-                : await _service.GetAll();
+            var result = await _service.GetAll(filter, sort, limit);
             return result.Value ?? [];
         }
     }

--- a/LifelogBb/McpControllers/EnduranceTrainingsTool.cs
+++ b/LifelogBb/McpControllers/EnduranceTrainingsTool.cs
@@ -1,4 +1,5 @@
-﻿using LifelogBb.ApiDTOs.EnduranceTrainings;
+﻿using LifelogBb.ApiDTOs;
+using LifelogBb.ApiDTOs.EnduranceTrainings;
 using LifelogBb.ApiServices;
 using ModelContextProtocol.Server;
 using System.ComponentModel;
@@ -12,17 +13,34 @@ namespace LifelogBb.McpControllers
         {
         }
 
-        [McpServerTool(Name = "GetAllEnduranceTrainings", Title = "Get All Endurance Trainings"), Description("Get all endurance training data. Optionally filter by providing a JSON filter expression.")]
-        public async Task<IEnumerable<EnduranceTrainingOutput>> McpGetAll([Description("Optional JSON filter expression")] string? filter = null)
+        [McpServerTool(Name = "GetAllEnduranceTrainings", Title = "Get All Endurance Trainings", ReadOnly = true, OpenWorld = false), Description("Get all endurance training data, newest first. Optionally filter by providing a JSON filter expression, sort by a field, and limit how many entries are returned. For the last workout use limit 1.")]
+        public async Task<IEnumerable<EnduranceTrainingOutput>> McpGetAll(
+            [Description("Optional JSON filter expression")] string? filter = null,
+            [Description("Optional sort field, for example \"CreatedAt\" ascending or \"CreatedAt_desc\" descending. Defaults to newest first.")] string? sort = null,
+            [Description("Optional maximum number of entries to return. Combine with sort to fetch only the entries you need.")] int? limit = null)
         {
-            return await GetAllFiltered(filter);
+            return await GetAllFiltered(filter, sort, limit);
         }
 
-        [McpServerTool(Name = "CreateEnduranceTraining", Title = "Create endurance training entry"), Description("Create a new endurance training entry")]
+        [McpServerTool(Name = "CreateEnduranceTraining", Title = "Create endurance training entry", Destructive = false, OpenWorld = false), Description("Create a new endurance training entry")]
         public async Task<EnduranceTrainingOutput?> Create(EnduranceTrainingInput model)
         {
             var result = await _service.Create(model);
             return result;
+        }
+
+        [McpServerTool(Name = "UpdateEnduranceTraining", Title = "Update endurance training entry", Destructive = true, Idempotent = true, OpenWorld = false), Description("Update an existing endurance training entry. All fields of the entry are replaced by the provided values.")]
+        public async Task<EnduranceTrainingOutput?> Update([Description("Id of the endurance training entry to update")] long id, EnduranceTrainingInput model)
+        {
+            var result = await _service.Update(id, model);
+            return result;
+        }
+
+        [McpServerTool(Name = "DeleteEnduranceTraining", Title = "Delete endurance training entry", Destructive = true, Idempotent = true, OpenWorld = false), Description("Delete an existing endurance training entry")]
+        public async Task<DeleteOutput?> Delete([Description("Id of the endurance training entry to delete")] long id)
+        {
+            var deletedId = await _service.Delete(id);
+            return deletedId == null ? null : new DeleteOutput() { Id = deletedId.Value };
         }
     }
 }

--- a/LifelogBb/McpControllers/GoalsTool.cs
+++ b/LifelogBb/McpControllers/GoalsTool.cs
@@ -1,4 +1,5 @@
-﻿using LifelogBb.ApiDTOs.Goals;
+﻿using LifelogBb.ApiDTOs;
+using LifelogBb.ApiDTOs.Goals;
 using LifelogBb.ApiServices;
 using ModelContextProtocol.Server;
 using System.ComponentModel;
@@ -12,17 +13,34 @@ namespace LifelogBb.McpControllers
         {
         }
 
-        [McpServerTool(Name = "GetAllGoals", Title = "Get All Goals"), Description("Get all goal data. Optionally filter by providing a JSON filter expression.")]
-        public async Task<IEnumerable<GoalOutput>> McpGetAll([Description("Optional JSON filter expression")] string? filter = null)
+        [McpServerTool(Name = "GetAllGoals", Title = "Get All Goals", ReadOnly = true, OpenWorld = false), Description("Get all goal data, newest first. Optionally filter by providing a JSON filter expression, sort by a field, and limit how many entries are returned.")]
+        public async Task<IEnumerable<GoalOutput>> McpGetAll(
+            [Description("Optional JSON filter expression")] string? filter = null,
+            [Description("Optional sort field, for example \"EndDate\" ascending or \"EndDate_desc\" descending. Defaults to newest first.")] string? sort = null,
+            [Description("Optional maximum number of entries to return. Combine with sort to fetch only the entries you need.")] int? limit = null)
         {
-            return await GetAllFiltered(filter);
+            return await GetAllFiltered(filter, sort, limit);
         }
 
-        [McpServerTool(Name = "CreateGoal", Title = "Create goal entry"), Description("Create a new goal entry")]
+        [McpServerTool(Name = "CreateGoal", Title = "Create goal entry", Destructive = false, OpenWorld = false), Description("Create a new goal entry")]
         public async Task<GoalOutput?> Create(GoalInput model)
         {
             var result = await _service.Create(model);
             return result;
+        }
+
+        [McpServerTool(Name = "UpdateGoal", Title = "Update goal entry", Destructive = true, Idempotent = true, OpenWorld = false), Description("Update an existing goal entry. All fields of the entry are replaced by the provided values.")]
+        public async Task<GoalOutput?> Update([Description("Id of the goal entry to update")] long id, GoalInput model)
+        {
+            var result = await _service.Update(id, model);
+            return result;
+        }
+
+        [McpServerTool(Name = "DeleteGoal", Title = "Delete goal entry", Destructive = true, Idempotent = true, OpenWorld = false), Description("Delete an existing goal entry")]
+        public async Task<DeleteOutput?> Delete([Description("Id of the goal entry to delete")] long id)
+        {
+            var deletedId = await _service.Delete(id);
+            return deletedId == null ? null : new DeleteOutput() { Id = deletedId.Value };
         }
     }
 }

--- a/LifelogBb/McpControllers/HabitsTool.cs
+++ b/LifelogBb/McpControllers/HabitsTool.cs
@@ -1,4 +1,5 @@
-﻿using LifelogBb.ApiDTOs.Habits;
+﻿using LifelogBb.ApiDTOs;
+using LifelogBb.ApiDTOs.Habits;
 using LifelogBb.ApiServices;
 using ModelContextProtocol.Server;
 using System.ComponentModel;
@@ -12,17 +13,34 @@ namespace LifelogBb.McpControllers
         {
         }
 
-        [McpServerTool(Name = "GetAllHabits", Title = "Get All Habits"), Description("Get all habit data. Optionally filter by providing a JSON filter expression.")]
-        public async Task<IEnumerable<HabitOutput>> McpGetAll([Description("Optional JSON filter expression")] string? filter = null)
+        [McpServerTool(Name = "GetAllHabits", Title = "Get All Habits", ReadOnly = true, OpenWorld = false), Description("Get all habit data, newest first. Optionally filter by providing a JSON filter expression, sort by a field, and limit how many entries are returned.")]
+        public async Task<IEnumerable<HabitOutput>> McpGetAll(
+            [Description("Optional JSON filter expression")] string? filter = null,
+            [Description("Optional sort field, for example \"CreatedAt\" ascending or \"CreatedAt_desc\" descending. Defaults to newest first.")] string? sort = null,
+            [Description("Optional maximum number of entries to return. Combine with sort to fetch only the entries you need.")] int? limit = null)
         {
-            return await GetAllFiltered(filter);
+            return await GetAllFiltered(filter, sort, limit);
         }
 
-        [McpServerTool(Name = "CreateHabit", Title = "Create habit entry"), Description("Create a new habit entry")]
+        [McpServerTool(Name = "CreateHabit", Title = "Create habit entry", Destructive = false, OpenWorld = false), Description("Create a new habit entry")]
         public async Task<HabitOutput?> Create(HabitInput model)
         {
             var result = await _service.Create(model);
             return result;
+        }
+
+        [McpServerTool(Name = "UpdateHabit", Title = "Update habit entry", Destructive = true, Idempotent = true, OpenWorld = false), Description("Update an existing habit entry. All fields of the entry are replaced by the provided values.")]
+        public async Task<HabitOutput?> Update([Description("Id of the habit entry to update")] long id, HabitInput model)
+        {
+            var result = await _service.Update(id, model);
+            return result;
+        }
+
+        [McpServerTool(Name = "DeleteHabit", Title = "Delete habit entry", Destructive = true, Idempotent = true, OpenWorld = false), Description("Delete an existing habit entry")]
+        public async Task<DeleteOutput?> Delete([Description("Id of the habit entry to delete")] long id)
+        {
+            var deletedId = await _service.Delete(id);
+            return deletedId == null ? null : new DeleteOutput() { Id = deletedId.Value };
         }
     }
 }

--- a/LifelogBb/McpControllers/JournalsTool.cs
+++ b/LifelogBb/McpControllers/JournalsTool.cs
@@ -1,4 +1,5 @@
-﻿using LifelogBb.ApiDTOs.Journals;
+﻿using LifelogBb.ApiDTOs;
+using LifelogBb.ApiDTOs.Journals;
 using LifelogBb.ApiServices;
 using ModelContextProtocol.Server;
 using System.ComponentModel;
@@ -12,17 +13,34 @@ namespace LifelogBb.McpControllers
         {
         }
 
-        [McpServerTool(Name = "GetAllJournals", Title = "Get All Journals"), Description("Get all journal data. Optionally filter by providing a JSON filter expression.")]
-        public async Task<IEnumerable<JournalOutput>> McpGetAll([Description("Optional JSON filter expression")] string? filter = null)
+        [McpServerTool(Name = "GetAllJournals", Title = "Get All Journals", ReadOnly = true, OpenWorld = false), Description("Get all journal data, newest first by journal date. Optionally filter by providing a JSON filter expression, sort by a field, and limit how many entries are returned. For the most recent entries use a small limit.")]
+        public async Task<IEnumerable<JournalOutput>> McpGetAll(
+            [Description("Optional JSON filter expression")] string? filter = null,
+            [Description("Optional sort field, for example \"Date\" ascending or \"Date_desc\" descending. Date is the day the entry is about, CreatedAt is when it was written. Defaults to the newest journal date first.")] string? sort = null,
+            [Description("Optional maximum number of entries to return. Combine with sort to fetch only the entries you need.")] int? limit = null)
         {
-            return await GetAllFiltered(filter);
+            return await GetAllFiltered(filter, sort, limit);
         }
 
-        [McpServerTool(Name = "CreateJournal", Title = "Create journal entry"), Description("Create a new journal entry")]
+        [McpServerTool(Name = "CreateJournal", Title = "Create journal entry", Destructive = false, OpenWorld = false), Description("Create a new journal entry")]
         public async Task<JournalOutput?> Create(JournalInput model)
         {
             var result = await _service.Create(model);
             return result;
+        }
+
+        [McpServerTool(Name = "UpdateJournal", Title = "Update journal entry", Destructive = true, Idempotent = true, OpenWorld = false), Description("Update an existing journal entry. All fields of the entry are replaced by the provided values.")]
+        public async Task<JournalOutput?> Update([Description("Id of the journal entry to update")] long id, JournalInput model)
+        {
+            var result = await _service.Update(id, model);
+            return result;
+        }
+
+        [McpServerTool(Name = "DeleteJournal", Title = "Delete journal entry", Destructive = true, Idempotent = true, OpenWorld = false), Description("Delete an existing journal entry")]
+        public async Task<DeleteOutput?> Delete([Description("Id of the journal entry to delete")] long id)
+        {
+            var deletedId = await _service.Delete(id);
+            return deletedId == null ? null : new DeleteOutput() { Id = deletedId.Value };
         }
     }
 }

--- a/LifelogBb/McpControllers/QuotesTool.cs
+++ b/LifelogBb/McpControllers/QuotesTool.cs
@@ -1,4 +1,5 @@
-﻿using LifelogBb.ApiDTOs.Quotes;
+﻿using LifelogBb.ApiDTOs;
+using LifelogBb.ApiDTOs.Quotes;
 using LifelogBb.ApiServices;
 using ModelContextProtocol.Server;
 using System.ComponentModel;
@@ -12,17 +13,34 @@ namespace LifelogBb.McpControllers
         {
         }
 
-        [McpServerTool(Name = "GetAllQuotes", Title = "Get All Quotes"), Description("Get all quote data. Optionally filter by providing a JSON filter expression.")]
-        public async Task<IEnumerable<QuoteOutput>> McpGetAll([Description("Optional JSON filter expression")] string? filter = null)
+        [McpServerTool(Name = "GetAllQuotes", Title = "Get All Quotes", ReadOnly = true, OpenWorld = false), Description("Get all quote data, newest first. Optionally filter by providing a JSON filter expression, sort by a field, and limit how many entries are returned.")]
+        public async Task<IEnumerable<QuoteOutput>> McpGetAll(
+            [Description("Optional JSON filter expression")] string? filter = null,
+            [Description("Optional sort field, for example \"CreatedAt\" ascending or \"CreatedAt_desc\" descending. Defaults to newest first.")] string? sort = null,
+            [Description("Optional maximum number of entries to return. Combine with sort to fetch only the entries you need.")] int? limit = null)
         {
-            return await GetAllFiltered(filter);
+            return await GetAllFiltered(filter, sort, limit);
         }
 
-        [McpServerTool(Name = "CreateQuote", Title = "Create quote entry"), Description("Create a new quote entry")]
+        [McpServerTool(Name = "CreateQuote", Title = "Create quote entry", Destructive = false, OpenWorld = false), Description("Create a new quote entry")]
         public async Task<QuoteOutput?> Create(QuoteInput model)
         {
             var result = await _service.Create(model);
             return result;
+        }
+
+        [McpServerTool(Name = "UpdateQuote", Title = "Update quote entry", Destructive = true, Idempotent = true, OpenWorld = false), Description("Update an existing quote entry. All fields of the entry are replaced by the provided values.")]
+        public async Task<QuoteOutput?> Update([Description("Id of the quote entry to update")] long id, QuoteInput model)
+        {
+            var result = await _service.Update(id, model);
+            return result;
+        }
+
+        [McpServerTool(Name = "DeleteQuote", Title = "Delete quote entry", Destructive = true, Idempotent = true, OpenWorld = false), Description("Delete an existing quote entry")]
+        public async Task<DeleteOutput?> Delete([Description("Id of the quote entry to delete")] long id)
+        {
+            var deletedId = await _service.Delete(id);
+            return deletedId == null ? null : new DeleteOutput() { Id = deletedId.Value };
         }
     }
 }

--- a/LifelogBb/McpControllers/StrengthTrainingsTool.cs
+++ b/LifelogBb/McpControllers/StrengthTrainingsTool.cs
@@ -1,4 +1,5 @@
-﻿using LifelogBb.ApiDTOs.StrengthTrainings;
+﻿using LifelogBb.ApiDTOs;
+using LifelogBb.ApiDTOs.StrengthTrainings;
 using LifelogBb.ApiServices;
 using ModelContextProtocol.Server;
 using System.ComponentModel;
@@ -12,17 +13,34 @@ namespace LifelogBb.McpControllers
         {
         }
 
-        [McpServerTool(Name = "GetAllStrengthTrainings", Title = "Get All Strength Trainings"), Description("Get all strength training data. Optionally filter by providing a JSON filter expression.")]
-        public async Task<IEnumerable<StrengthTrainingOutput>> McpGetAll([Description("Optional JSON filter expression")] string? filter = null)
+        [McpServerTool(Name = "GetAllStrengthTrainings", Title = "Get All Strength Trainings", ReadOnly = true, OpenWorld = false), Description("Get all strength training data, newest first. Optionally filter by providing a JSON filter expression, sort by a field, and limit how many entries are returned. For the last workout use limit 1.")]
+        public async Task<IEnumerable<StrengthTrainingOutput>> McpGetAll(
+            [Description("Optional JSON filter expression")] string? filter = null,
+            [Description("Optional sort field, for example \"CreatedAt\" ascending or \"CreatedAt_desc\" descending. Defaults to newest first.")] string? sort = null,
+            [Description("Optional maximum number of entries to return. Combine with sort to fetch only the entries you need.")] int? limit = null)
         {
-            return await GetAllFiltered(filter);
+            return await GetAllFiltered(filter, sort, limit);
         }
 
-        [McpServerTool(Name = "CreateStrengthTraining", Title = "Create strength training entry"), Description("Create a new strength training entry")]
+        [McpServerTool(Name = "CreateStrengthTraining", Title = "Create strength training entry", Destructive = false, OpenWorld = false), Description("Create a new strength training entry")]
         public async Task<StrengthTrainingOutput?> Create(StrengthTrainingInput model)
         {
             var result = await _service.Create(model);
             return result;
+        }
+
+        [McpServerTool(Name = "UpdateStrengthTraining", Title = "Update strength training entry", Destructive = true, Idempotent = true, OpenWorld = false), Description("Update an existing strength training entry. All fields of the entry are replaced by the provided values.")]
+        public async Task<StrengthTrainingOutput?> Update([Description("Id of the strength training entry to update")] long id, StrengthTrainingInput model)
+        {
+            var result = await _service.Update(id, model);
+            return result;
+        }
+
+        [McpServerTool(Name = "DeleteStrengthTraining", Title = "Delete strength training entry", Destructive = true, Idempotent = true, OpenWorld = false), Description("Delete an existing strength training entry")]
+        public async Task<DeleteOutput?> Delete([Description("Id of the strength training entry to delete")] long id)
+        {
+            var deletedId = await _service.Delete(id);
+            return deletedId == null ? null : new DeleteOutput() { Id = deletedId.Value };
         }
     }
 }

--- a/LifelogBb/McpControllers/TodosTool.cs
+++ b/LifelogBb/McpControllers/TodosTool.cs
@@ -1,4 +1,5 @@
-﻿using LifelogBb.ApiDTOs.Todos;
+﻿using LifelogBb.ApiDTOs;
+using LifelogBb.ApiDTOs.Todos;
 using LifelogBb.ApiServices;
 using ModelContextProtocol.Server;
 using System.ComponentModel;
@@ -12,17 +13,34 @@ namespace LifelogBb.McpControllers
         {
         }
 
-        [McpServerTool(Name = "GetAllTodos", Title = "Get All Todos"), Description("Get all todo data. Optionally filter by providing a JSON filter expression.")]
-        public async Task<IEnumerable<TodoOutput>> McpGetAll([Description("Optional JSON filter expression")] string? filter = null)
+        [McpServerTool(Name = "GetAllTodos", Title = "Get All Todos", ReadOnly = true, OpenWorld = false), Description("Get all todo data, newest first. Optionally filter by providing a JSON filter expression, sort by a field, and limit how many entries are returned.")]
+        public async Task<IEnumerable<TodoOutput>> McpGetAll(
+            [Description("Optional JSON filter expression")] string? filter = null,
+            [Description("Optional sort field, for example \"DueDate\" ascending or \"DueDate_desc\" descending. Defaults to newest first.")] string? sort = null,
+            [Description("Optional maximum number of entries to return. Combine with sort to fetch only the entries you need.")] int? limit = null)
         {
-            return await GetAllFiltered(filter);
+            return await GetAllFiltered(filter, sort, limit);
         }
 
-        [McpServerTool(Name = "CreateTodo", Title = "Create todo entry"), Description("Create a new todo entry")]
+        [McpServerTool(Name = "CreateTodo", Title = "Create todo entry", Destructive = false, OpenWorld = false), Description("Create a new todo entry")]
         public async Task<TodoOutput?> Create(TodoInput model)
         {
             var result = await _service.Create(model);
             return result;
+        }
+
+        [McpServerTool(Name = "UpdateTodo", Title = "Update todo entry", Destructive = true, Idempotent = true, OpenWorld = false), Description("Update an existing todo entry. All fields of the entry are replaced by the provided values.")]
+        public async Task<TodoOutput?> Update([Description("Id of the todo entry to update")] long id, TodoInput model)
+        {
+            var result = await _service.Update(id, model);
+            return result;
+        }
+
+        [McpServerTool(Name = "DeleteTodo", Title = "Delete todo entry", Destructive = true, Idempotent = true, OpenWorld = false), Description("Delete an existing todo entry")]
+        public async Task<DeleteOutput?> Delete([Description("Id of the todo entry to delete")] long id)
+        {
+            var deletedId = await _service.Delete(id);
+            return deletedId == null ? null : new DeleteOutput() { Id = deletedId.Value };
         }
     }
 }

--- a/LifelogBb/McpControllers/WeightsTool.cs
+++ b/LifelogBb/McpControllers/WeightsTool.cs
@@ -1,4 +1,5 @@
-﻿using LifelogBb.ApiDTOs.Weights;
+﻿using LifelogBb.ApiDTOs;
+using LifelogBb.ApiDTOs.Weights;
 using LifelogBb.ApiServices;
 using ModelContextProtocol.Server;
 using System.ComponentModel;
@@ -12,17 +13,34 @@ namespace LifelogBb.McpControllers
         {
         }
 
-        [McpServerTool(Name = "GetAllWeights", Title = "Get All Weights"), Description("Get all weight data. Optionally filter by providing a JSON filter expression.")]
-        public async Task<IEnumerable<WeightOutput>> McpGetAll([Description("Optional JSON filter expression")] string? filter = null)
+        [McpServerTool(Name = "GetAllWeights", Title = "Get All Weights", ReadOnly = true, OpenWorld = false), Description("Get all weight data, newest first. Optionally filter by providing a JSON filter expression, sort by a field, and limit how many entries are returned. For the current weight use limit 1.")]
+        public async Task<IEnumerable<WeightOutput>> McpGetAll(
+            [Description("Optional JSON filter expression")] string? filter = null,
+            [Description("Optional sort field, for example \"CreatedAt\" ascending or \"CreatedAt_desc\" descending. Defaults to newest first.")] string? sort = null,
+            [Description("Optional maximum number of entries to return. Combine with sort to fetch only the entries you need.")] int? limit = null)
         {
-            return await GetAllFiltered(filter);
+            return await GetAllFiltered(filter, sort, limit);
         }
 
-        [McpServerTool(Name = "CreateWeight", Title = "Create weight entry"), Description("Create a new weight entry")]
+        [McpServerTool(Name = "CreateWeight", Title = "Create weight entry", Destructive = false, OpenWorld = false), Description("Create a new weight entry")]
         public async Task<WeightOutput?> Create(WeightInput model)
         {
             var result = await _service.Create(model);
             return result;
+        }
+
+        [McpServerTool(Name = "UpdateWeight", Title = "Update weight entry", Destructive = true, Idempotent = true, OpenWorld = false), Description("Update an existing weight entry. All fields of the entry are replaced by the provided values.")]
+        public async Task<WeightOutput?> Update([Description("Id of the weight entry to update")] long id, WeightInput model)
+        {
+            var result = await _service.Update(id, model);
+            return result;
+        }
+
+        [McpServerTool(Name = "DeleteWeight", Title = "Delete weight entry", Destructive = true, Idempotent = true, OpenWorld = false), Description("Delete an existing weight entry")]
+        public async Task<DeleteOutput?> Delete([Description("Id of the weight entry to delete")] long id)
+        {
+            var deletedId = await _service.Delete(id);
+            return deletedId == null ? null : new DeleteOutput() { Id = deletedId.Value };
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Every area (weights, journals, todos, goals, habits, quotes, strength and endura
 | --- | --- |
 | `filter` | A JSON filter expression restricting which entries are returned. |
 | `sort` | Field to sort by. Append `_desc` for descending order, e.g. `CreatedAt_desc`. An unknown field is rejected instead of being ignored. |
-| `limit` | Maximum number of entries to return. |
+| `limit` | Maximum number of entries to return. Must be at least 1. |
 
 Whenever one of these parameters is used the results are sorted, so a `limit` returns a predictable set. Without an explicit `sort` the newest entries come first — by `CreatedAt` for most areas, and by the journal `Date` for journals, since that is the day an entry is about rather than the day it was written. Combining `sort` and `limit` is the way to ask for the latest entries, for example `limit` 1 for the current weight or the last workout, instead of fetching an entire area.
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,38 @@ Replace `https://your-lifelogbb-host` with the URL of your LifelogBB instance an
 
 The MCP token grants full read and write access to all of your life-log data and never expires. Only use it over HTTPS and treat it like a password.
 
+### Filtering, sorting and limiting results
+
+Every area (weights, journals, todos, goals, habits, quotes, strength and endurance trainings) offers `GetAll`, `Create`, `Update` and `Delete` tools. The `GetAll` tools take three optional parameters, which are also available on the REST API as the `filter`, `sort` and `limit` query parameters.
+
+| Parameter | Description |
+| --- | --- |
+| `filter` | A JSON filter expression restricting which entries are returned. |
+| `sort` | Field to sort by. Append `_desc` for descending order, e.g. `CreatedAt_desc`. An unknown field is rejected instead of being ignored. |
+| `limit` | Maximum number of entries to return. |
+
+Whenever one of these parameters is used the results are sorted, so a `limit` returns a predictable set. Without an explicit `sort` the newest entries come first — by `CreatedAt` for most areas, and by the journal `Date` for journals, since that is the day an entry is about rather than the day it was written. Combining `sort` and `limit` is the way to ask for the latest entries, for example `limit` 1 for the current weight or the last workout, instead of fetching an entire area.
+
+The `filter` expression is a group of conditions, optionally nested via `groups`:
+
+```json
+{
+  "operator": "And",
+  "conditions": [
+    { "field": "BodyWeight", "operator": "GreaterThan", "value": "80" }
+  ]
+}
+```
+
+`operator` on the group is `And` or `Or`. A condition supports `Equal`, `NotEqual`, `GreaterThan`, `GreaterThanOrEqual`, `LessThan`, `LessThanOrEqual`, `Contains`, `NotContains`, `In` and `NotIn`.
+
+The same options on the REST API:
+
+```sh
+curl -H "Authorization: Bearer <your-token>" \
+  "https://your-lifelogbb-host/api/weights?sort=CreatedAt_desc&limit=1"
+```
+
 ## Development
 
 Clone the repository and either install [Visual Studio](https://visualstudio.microsoft.com/) or just the [dotnet tools](https://dotnet.microsoft.com/en-us/learn/aspnet/hello-world-tutorial/install).


### PR DESCRIPTION
## What changed

**Update and Delete tools for every area.** Weights, journals, todos, goals, habits, quotes, strength and endurance trainings each exposed only `GetAll` and `Create` over MCP, so an assistant could add data but never correct or remove it. All eight areas now have `Update` and `Delete`, delegating to the `Update`/`Delete` that `IBaseCRUDService` already provided. `Update` takes the same `*Input` DTO as `Create` and is a full replace (that is what `BaseCRUDService.Update` does via AutoMapper), which the tool descriptions state explicitly so a model does not send partial objects. `Delete` returns `DeleteOutput { Id }`, matching `BaseCRUDController`.

**The filter path learned to sort and limit.** `FilterByGroup` only ever built a `Where` predicate and `GetAll` did a plain `ToListAsync()`, so results came back in whatever order SQLite produced and "what is my current weight" could not be expressed as a filter — clients had to fetch an entire area and sort locally. `GetAll` now takes optional `sortOrder` and `limit`, wiring in the existing `SortByName` helper, exposed as `sort` and `limit` on both the MCP tools and the REST API.

**Annotations on all 32 tools.** Previously every tool inherited the protocol defaults of not read-only and possibly destructive, so a client could not tell `GetAllWeights` apart from `DeleteWeight`. Readers are now `ReadOnly`, creates `Destructive = false`, updates and deletes `Destructive` + `Idempotent`, and all are `OpenWorld = false` since they only touch the local database.

## Notes for review

- **Ordering behaviour changed.** Whenever `filter`, `sort` or `limit` is used the results are now sorted, because a limit is meaningless without a deterministic order. Existing filtered API responses become ordered newest-first rather than arbitrary. The parameterless `GetAll()` is untouched.
- **Journals sort by `Date`, everything else by `CreatedAt`.** A journal's `Date` is the day it is *about*, which can differ from when it was written. Rather than making clients know that, `DefaultSortOrder` is a virtual property overridden in `JournalsService` — the same `Date_desc` default the MVC journal list already uses.
- **Unknown sort fields throw.** `SortByName` silently falls back to its default for a field that does not exist, which would let a typo'd `sort=Dat_desc` look like a successful sort. `EnsureSortableField` throws `ArgumentException`, which the controller already turns into a 400 and MCP surfaces as a tool error — consistent with how invalid filter JSON is handled.
- **Annotations are hints, not a security boundary.** The spec is explicit that clients must not rely on them for security decisions. Read-only access that genuinely cannot delete anything would need separate endpoints or a scoped token; that is deliberately not in this PR.
- `BaseRService`/`BaseRController`/`IBaseRService` carry their own copy of the filter code but have no users at all, so they were left alone.

## Verification

Builds clean (0 errors, no new warnings). The `SortByName` + `Take` combination is the same one already running in the MVC controllers via `PaginatedList`, so the EF/SQLite translation is proven, and the annotation properties are compile-checked against the SDK.

Not runtime-verified: the repo has no test project (`_tests` holds only a Postman collection) and the endpoints need auth, so the new query path was not executed and no MCP client was pointed at the server. The Postman collection would be the natural place to add `sort`/`limit` cases.

## Docs

README gained a "Filtering, sorting and limiting results" section under MCP Server. It previously documented neither the tool list nor the existing `filter` parameter, so the new section covers all three parameters together, plus the filter JSON shape and operator list taken from `FilterGroup`/`FilterCondition`/`ComparisonOperator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)