### PR TITLE
Add iCal DISPLAY reminders (VALARM) for Habits, Todos and Goals

### DIFF
--- a/LifelogBb/ApiDTOs/Goals/GoalInput.cs
+++ b/LifelogBb/ApiDTOs/Goals/GoalInput.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using LifelogBb.Utilities;
 
 namespace LifelogBb.ApiDTOs.Goals
 {
@@ -20,6 +21,10 @@ namespace LifelogBb.ApiDTOs.Goals
         public DateTime? StartDate { get; set; }
 
         public DateTime? EndDate { get; set; }
+
+        [Description("Reminders before the end date as a comma separated list of negative ISO-8601 durations, for example \"-PT15M,-P1D\"")]
+        [RegularExpression(AlarmHelper.Pattern, ErrorMessage = "Reminders must be a comma separated list of negative ISO-8601 durations like -PT15M,-P1D")]
+        public string? Alarms { get; set; }
 
         [DefaultValue(false)]
         public bool IsCompleted { get; set; }

--- a/LifelogBb/ApiDTOs/Goals/GoalOutput.cs
+++ b/LifelogBb/ApiDTOs/Goals/GoalOutput.cs
@@ -24,6 +24,8 @@ namespace LifelogBb.ApiDTOs.Goals
 
         public DateTime? EndDate { get; set; }
 
+        public string? Alarms { get; set; }
+
         public bool IsCompleted { get; set; }
 
         public string? Category { get; set; }

--- a/LifelogBb/ApiDTOs/Habits/HabitInput.cs
+++ b/LifelogBb/ApiDTOs/Habits/HabitInput.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using LifelogBb.Utilities;
 
 namespace LifelogBb.ApiDTOs.Habits
 {
@@ -16,6 +17,10 @@ namespace LifelogBb.ApiDTOs.Habits
         public DateTime? EndDate { get; set; }
 
         public string? RecurrenceRules { get; set; }
+
+        [Description("Reminders before the start date as a comma separated list of negative ISO-8601 durations, for example \"-PT15M,-P1D\"")]
+        [RegularExpression(AlarmHelper.Pattern, ErrorMessage = "Reminders must be a comma separated list of negative ISO-8601 durations like -PT15M,-P1D")]
+        public string? Alarms { get; set; }
 
         [DefaultValue(false)]
         public bool IsCompleted { get; set; }

--- a/LifelogBb/ApiDTOs/Habits/HabitOutput.cs
+++ b/LifelogBb/ApiDTOs/Habits/HabitOutput.cs
@@ -17,6 +17,8 @@ namespace LifelogBb.ApiDTOs.Habits
 
         public string? RecurrenceRules { get; set; }
 
+        public string? Alarms { get; set; }
+
         public bool IsCompleted { get; set; }
 
         public string? Category { get; set; }

--- a/LifelogBb/ApiDTOs/Todos/TodoInput.cs
+++ b/LifelogBb/ApiDTOs/Todos/TodoInput.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Xml.Linq;
+using LifelogBb.Utilities;
 
 namespace LifelogBb.ApiDTOs.Todos
 {
@@ -15,6 +16,10 @@ namespace LifelogBb.ApiDTOs.Todos
         public DateTime? StartDate { get; set; }
 
         public DateTime? DueDate { get; set; }
+
+        [Description("Reminders before the due date as a comma separated list of negative ISO-8601 durations, for example \"-PT15M,-P1D\"")]
+        [RegularExpression(AlarmHelper.Pattern, ErrorMessage = "Reminders must be a comma separated list of negative ISO-8601 durations like -PT15M,-P1D")]
+        public string? Alarms { get; set; }
 
         [Range(0, 100)]
         public int Progress { get; set; }

--- a/LifelogBb/ApiDTOs/Todos/TodoOutput.cs
+++ b/LifelogBb/ApiDTOs/Todos/TodoOutput.cs
@@ -19,6 +19,8 @@ namespace LifelogBb.ApiDTOs.Todos
 
         public DateTime? DueDate { get; set; }
 
+        public string? Alarms { get; set; }
+
         public int Progress { get; set; }
 
         public bool IsCompleted { get; set; }

--- a/LifelogBb/Controllers/GoalsController.cs
+++ b/LifelogBb/Controllers/GoalsController.cs
@@ -104,7 +104,7 @@ namespace LifelogBb.Controllers
         // POST: Goals/Create
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Create([Bind("Name,Description,InitialValue,TargetValue,CurrentValue,StartDate,EndDate,IsCompleted,Category,Tags")] Goal goal)
+        public async Task<IActionResult> Create([Bind("Name,Description,InitialValue,TargetValue,CurrentValue,StartDate,EndDate,Alarms,IsCompleted,Category,Tags")] Goal goal)
         {
             if (ModelState.IsValid)
             {
@@ -146,7 +146,7 @@ namespace LifelogBb.Controllers
         // POST: Goals/Edit/5
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Edit(long id, [Bind("Name,Description,InitialValue,TargetValue,CurrentValue,StartDate,EndDate,IsCompleted,Category,Tags,Id")] EditGoalViewModel goalViewModel)
+        public async Task<IActionResult> Edit(long id, [Bind("Name,Description,InitialValue,TargetValue,CurrentValue,StartDate,EndDate,Alarms,IsCompleted,Category,Tags,Id")] EditGoalViewModel goalViewModel)
         {
             if (id != goalViewModel.Id)
             {
@@ -243,7 +243,7 @@ namespace LifelogBb.Controllers
                     percentage = Convert.ToInt32(Math.Round((diffCurrent / diffTarget) * 100));
                 }
 
-                calendar.Todos.Add(new Ical.Net.CalendarComponents.Todo()
+                var calTodo = new Ical.Net.CalendarComponents.Todo()
                 {
                     Uid = goal.Id.ToString(),
                     Url = new Uri(Url.Action(nameof(Details), nameof(GoalsController).Replace("Controller", ""), new { id = goal.Id }, "https", Request.Host.Value)!),
@@ -251,11 +251,23 @@ namespace LifelogBb.Controllers
                     Description = $"{goal.Description}\n\nInitial Value: {goal.InitialValue}\nCurrent Value: {goal.CurrentValue}\nTarget Value: {goal.TargetValue}\n",
                     Completed = goal.EndDate.HasValue ? new CalDateTime(goal.EndDate.Value) : null,
                     Start = goal.StartDate.HasValue ? new CalDateTime(goal.StartDate.Value) : null,
+                    Due = goal.EndDate.HasValue ? new CalDateTime(goal.EndDate.Value) : null,
                     Priority = 0, // habit.IsImportant ? 1 : 5, // 0-9, 0=undefined, 1=highest, 9=lowest
                     Status = goal.IsCompleted ? "COMPLETED" : (percentage > 0 ? "IN-PROCESS" : ""),
                     Categories = new List<string>() { goal.Category ?? "" },
                     PercentComplete = percentage, // 0 = not started, 1=100
-                });
+                };
+
+                // Reminders trigger relative to DUE, so they need an end date to anchor to
+                if (goal.EndDate.HasValue)
+                {
+                    foreach (var alarm in AlarmHelper.BuildAlarms(goal.Alarms, goal.Name, TriggerRelation.End))
+                    {
+                        calTodo.Alarms.Add(alarm);
+                    }
+                }
+
+                calendar.Todos.Add(calTodo);
             });
 
             var serializer = new CalendarSerializer();

--- a/LifelogBb/Controllers/HabitsController.cs
+++ b/LifelogBb/Controllers/HabitsController.cs
@@ -147,7 +147,7 @@ namespace LifelogBb.Controllers
         // POST: Habits/Create
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Create([Bind("Name,Description,StartDate,EndDate,RecurrenceRules,IsCompleted,Category,Tags")] Habit habit)
+        public async Task<IActionResult> Create([Bind("Name,Description,StartDate,EndDate,RecurrenceRules,Alarms,IsCompleted,Category,Tags")] Habit habit)
         {
             if (ModelState.IsValid)
             {
@@ -185,7 +185,7 @@ namespace LifelogBb.Controllers
         // POST: Habits/Edit/5
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Edit(long id, [Bind("Name,Description,StartDate,EndDate,RecurrenceRules,IsCompleted,Category,Tags,Id")] EditHabitViewModel habitViewModel)
+        public async Task<IActionResult> Edit(long id, [Bind("Name,Description,StartDate,EndDate,RecurrenceRules,Alarms,IsCompleted,Category,Tags,Id")] EditHabitViewModel habitViewModel)
         {
             if (id != habitViewModel.Id)
             {
@@ -298,6 +298,12 @@ namespace LifelogBb.Controllers
                     // Ical.Net 5: RecurrencePattern constructor no longer accepts the "RRULE:" prefix
                     RecurrencePattern recurrenceRule = new RecurrencePattern(RecurrenceRuleHelper.Normalize(habit.RecurrenceRules));
                     calEvent.RecurrenceRules = new List<RecurrencePattern>() { recurrenceRule };
+                }
+
+                // Reminders trigger relative to DTSTART, so they repeat with every occurrence
+                foreach (var alarm in AlarmHelper.BuildAlarms(habit.Alarms, habit.Name, TriggerRelation.Start))
+                {
+                    calEvent.Alarms.Add(alarm);
                 }
 
                 calendar.Events.Add(calEvent);

--- a/LifelogBb/Controllers/TodosController.cs
+++ b/LifelogBb/Controllers/TodosController.cs
@@ -113,7 +113,7 @@ namespace LifelogBb.Controllers
         // POST: Todos/Create
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Create([Bind("Title,Description,DueDate,IsCompleted,IsImportant,Category,Tags,StartDate,Progress,Progress")] Todo todo)
+        public async Task<IActionResult> Create([Bind("Title,Description,DueDate,Alarms,IsCompleted,IsImportant,Category,Tags,StartDate,Progress,Progress")] Todo todo)
         {
             if (ModelState.IsValid)
             {
@@ -155,7 +155,7 @@ namespace LifelogBb.Controllers
         // POST: Todos/Edit/5
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Edit(long id, [Bind("Title,Description,DueDate,IsCompleted,IsImportant,Category,Tags,StartDate,Progress,Progress,Id")] EditTodoViewModel todoViewModel)
+        public async Task<IActionResult> Edit(long id, [Bind("Title,Description,DueDate,Alarms,IsCompleted,IsImportant,Category,Tags,StartDate,Progress,Progress,Id")] EditTodoViewModel todoViewModel)
         {
             if (id != todoViewModel.Id)
             {
@@ -248,7 +248,7 @@ namespace LifelogBb.Controllers
             var todos = await todosQuery.ToListAsync();
             todos.ToList().ForEach(todo =>
             {
-                calendar.Todos.Add(new CalendarComponents.Todo()
+                var calTodo = new CalendarComponents.Todo()
                 {
                     Uid = todo.Id.ToString(),
                     Url = new Uri(Url.Action(nameof(Details), nameof(TodosController).Replace("Controller", ""), new { id = todo.Id }, "https", Request.Host.Value)!),
@@ -256,11 +256,23 @@ namespace LifelogBb.Controllers
                     Description = todo.Description,
                     Completed = todo.Completed.HasValue ? new CalDateTime(todo.Completed.Value) : null,
                     Start = todo.StartDate.HasValue ? new CalDateTime(todo.StartDate.Value) : null,
+                    Due = todo.DueDate.HasValue ? new CalDateTime(todo.DueDate.Value) : null,
                     Priority = todo.IsImportant ? 1 : 5, // 0-9, 0=undefined, 1=highest, 9=lowest
                     Status = todo.IsCompleted || todo.Completed.HasValue ? "COMPLETED" : (todo.Progress > 0 ? "IN-PROCESS" : ""),
                     Categories = new List<string>() { todo.Category ?? "" },
                     PercentComplete = todo.Progress, // 0 = not started, 1=100
-                });
+                };
+
+                // Reminders trigger relative to DUE, so they need a due date to anchor to
+                if (todo.DueDate.HasValue)
+                {
+                    foreach (var alarm in AlarmHelper.BuildAlarms(todo.Alarms, todo.Title, TriggerRelation.End))
+                    {
+                        calTodo.Alarms.Add(alarm);
+                    }
+                }
+
+                calendar.Todos.Add(calTodo);
             });
 
             var serializer = new CalendarSerializer();

--- a/LifelogBb/Migrations/20260808061058_IcalAlarms.Designer.cs
+++ b/LifelogBb/Migrations/20260808061058_IcalAlarms.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LifelogBb.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LifelogBb.Migrations
 {
     [DbContext(typeof(LifelogBbContext))]
-    partial class LifelogBbContextModelSnapshot : ModelSnapshot
+    [Migration("20260808061058_IcalAlarms")]
+    partial class IcalAlarms
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/LifelogBb/Migrations/20260808061058_IcalAlarms.cs
+++ b/LifelogBb/Migrations/20260808061058_IcalAlarms.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LifelogBb.Migrations
+{
+    /// <inheritdoc />
+    public partial class IcalAlarms : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Alarms",
+                table: "Todos",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Alarms",
+                table: "Habits",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Alarms",
+                table: "Goals",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Alarms",
+                table: "Todos");
+
+            migrationBuilder.DropColumn(
+                name: "Alarms",
+                table: "Habits");
+
+            migrationBuilder.DropColumn(
+                name: "Alarms",
+                table: "Goals");
+        }
+    }
+}

--- a/LifelogBb/Models/Entities/Goal.cs
+++ b/LifelogBb/Models/Entities/Goal.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using LifelogBb.Utilities;
 
 namespace LifelogBb.Models.Entities
 {
@@ -23,6 +24,10 @@ namespace LifelogBb.Models.Entities
         public DateTime? StartDate { get; set; }
 
         public DateTime? EndDate { get; set; }
+
+        [Display(Name = "Reminders")]
+        [RegularExpression(AlarmHelper.Pattern, ErrorMessage = "Reminders must be a comma separated list of negative ISO-8601 durations like -PT15M,-P1D")]
+        public string? Alarms { get; set; }
 
         [DefaultValue(false)]
         public bool IsCompleted { get; set; }

--- a/LifelogBb/Models/Entities/Habit.cs
+++ b/LifelogBb/Models/Entities/Habit.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using LifelogBb.Utilities;
 
 namespace LifelogBb.Models.Entities
 {
@@ -16,6 +17,10 @@ namespace LifelogBb.Models.Entities
         public DateTime? EndDate { get; set; }
 
         public string? RecurrenceRules { get; set; }
+
+        [Display(Name = "Reminders")]
+        [RegularExpression(AlarmHelper.Pattern, ErrorMessage = "Reminders must be a comma separated list of negative ISO-8601 durations like -PT15M,-P1D")]
+        public string? Alarms { get; set; }
 
         [DefaultValue(false)]
         public bool IsCompleted { get; set; }

--- a/LifelogBb/Models/Entities/Todo.cs
+++ b/LifelogBb/Models/Entities/Todo.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using LifelogBb.Utilities;
 
 namespace LifelogBb.Models.Entities
 {
@@ -18,6 +19,10 @@ namespace LifelogBb.Models.Entities
         [Display(Name = "Due")]
         [DataType(DataType.DateTime)]
         public DateTime? DueDate { get; set; }
+
+        [Display(Name = "Reminders")]
+        [RegularExpression(AlarmHelper.Pattern, ErrorMessage = "Reminders must be a comma separated list of negative ISO-8601 durations like -PT15M,-P1D")]
+        public string? Alarms { get; set; }
 
         [DisplayName("Progress")]
         [Range(0, 100)]

--- a/LifelogBb/Models/Goals/EditGoalViewModel.cs
+++ b/LifelogBb/Models/Goals/EditGoalViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel;
+using LifelogBb.Utilities;
 
 namespace LifelogBb.Models.Goals
 {
@@ -22,6 +23,10 @@ namespace LifelogBb.Models.Goals
         public DateTime? StartDate { get; set; }
 
         public DateTime? EndDate { get; set; }
+
+        [Display(Name = "Reminders")]
+        [RegularExpression(AlarmHelper.Pattern, ErrorMessage = "Reminders must be a comma separated list of negative ISO-8601 durations like -PT15M,-P1D")]
+        public string? Alarms { get; set; }
 
         [DefaultValue(false)]
         public bool IsCompleted { get; set; }

--- a/LifelogBb/Models/Habits/EditHabitViewModel.cs
+++ b/LifelogBb/Models/Habits/EditHabitViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel;
+using LifelogBb.Utilities;
 
 namespace LifelogBb.Models.Habits
 {
@@ -18,6 +19,10 @@ namespace LifelogBb.Models.Habits
         public DateTime? EndDate { get; set; }
 
         public string? RecurrenceRules { get; set; }
+
+        [Display(Name = "Reminders")]
+        [RegularExpression(AlarmHelper.Pattern, ErrorMessage = "Reminders must be a comma separated list of negative ISO-8601 durations like -PT15M,-P1D")]
+        public string? Alarms { get; set; }
 
         [DefaultValue(false)]
         public bool IsCompleted { get; set; }

--- a/LifelogBb/Models/Todos/EditTodoViewModel.cs
+++ b/LifelogBb/Models/Todos/EditTodoViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel;
+using LifelogBb.Utilities;
 
 namespace LifelogBb.Models.Todos
 {
@@ -16,6 +17,10 @@ namespace LifelogBb.Models.Todos
         public DateTime? Start { get; set; }
 
         public DateTime? DueDate { get; set; }
+
+        [Display(Name = "Reminders")]
+        [RegularExpression(AlarmHelper.Pattern, ErrorMessage = "Reminders must be a comma separated list of negative ISO-8601 durations like -PT15M,-P1D")]
+        public string? Alarms { get; set; }
 
         [Range(0, 100)]
         public int Progress { get; set; }

--- a/LifelogBb/Utilities/AlarmHelper.cs
+++ b/LifelogBb/Utilities/AlarmHelper.cs
@@ -1,0 +1,145 @@
+using System.Text.RegularExpressions;
+using Ical.Net;
+using Ical.Net.CalendarComponents;
+using Ical.Net.DataTypes;
+
+namespace LifelogBb.Utilities;
+
+/// <summary>
+/// A single reminder lead time, for example "15 minutes before".
+/// </summary>
+/// <param name="Amount">How much time before the anchor date the reminder fires.</param>
+/// <param name="Unit">'M' for minutes, 'H' for hours, 'D' for days.</param>
+public readonly record struct AlarmOffset(int Amount, char Unit)
+{
+    /// <summary>Renders the offset as the negative ISO-8601 duration used in TRIGGER.</summary>
+    public string ToDurationString() => Unit == 'D' ? $"-P{Amount}D" : $"-PT{Amount}{Unit}";
+
+    /// <summary>Renders the offset as human readable text, for example "15 minutes before".</summary>
+    public string ToText() => Unit switch
+    {
+        'M' => $"{Amount} minute{(Amount == 1 ? "" : "s")} before",
+        'H' => $"{Amount} hour{(Amount == 1 ? "" : "s")} before",
+        _ => $"{Amount} day{(Amount == 1 ? "" : "s")} before",
+    };
+
+    /// <summary>
+    /// Converts the offset to the negative <see cref="Duration"/> expected by Ical.Net.
+    /// Days stay nominal ("-P1D") instead of being expanded to hours.
+    /// </summary>
+    public Duration ToNegativeDuration() => Unit switch
+    {
+        'M' => Duration.FromMinutes(-Amount),
+        'H' => Duration.FromHours(-Amount),
+        _ => Duration.FromDays(-Amount),
+    };
+}
+
+/// <summary>
+/// Helpers for the reminder lead times stored on habits, todos and goals.
+/// <para>
+/// Lead times are persisted as a comma separated list of negative ISO-8601 durations,
+/// exactly as they appear in an iCalendar TRIGGER property: "-PT15M,-PT2H,-P1D".
+/// A null or empty value means the entry has no reminders.
+/// </para>
+/// </summary>
+public static class AlarmHelper
+{
+    /// <summary>Maximum number of reminders kept per entry.</summary>
+    public const int MaxAlarms = 10;
+
+    /// <summary>
+    /// Validation pattern for the stored list. Declared as a const so it can be passed to
+    /// <see cref="System.ComponentModel.DataAnnotations.RegularExpressionAttribute"/>.
+    /// </summary>
+    public const string Pattern = @"^\s*$|^\s*-P(T\d{1,4}[HM]|\d{1,4}D)(\s*,\s*-P(T\d{1,4}[HM]|\d{1,4}D))*\s*$";
+
+    private static readonly Regex EntryRegex = new(
+        @"^-P(?:T(?<amount>\d{1,4})(?<unit>[HM])|(?<amount>\d{1,4})(?<unit>D))$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// Parses the stored list into offsets. Entries that cannot be read are skipped rather than
+    /// throwing, so bad data can never break a calendar feed. Duplicates are dropped and the
+    /// result is capped at <see cref="MaxAlarms"/>.
+    /// </summary>
+    public static IReadOnlyList<AlarmOffset> Parse(string? alarms)
+    {
+        if (string.IsNullOrWhiteSpace(alarms))
+        {
+            return Array.Empty<AlarmOffset>();
+        }
+
+        var offsets = new List<AlarmOffset>();
+        foreach (var part in alarms.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var match = EntryRegex.Match(part);
+            if (!match.Success)
+            {
+                continue;
+            }
+
+            var amount = int.Parse(match.Groups["amount"].Value);
+            if (amount <= 0)
+            {
+                continue;
+            }
+
+            var offset = new AlarmOffset(amount, match.Groups["unit"].Value[0]);
+            if (!offsets.Contains(offset))
+            {
+                offsets.Add(offset);
+            }
+
+            if (offsets.Count >= MaxAlarms)
+            {
+                break;
+            }
+        }
+
+        return offsets;
+    }
+
+    /// <summary>Human readable text for every reminder, used by the display template.</summary>
+    public static IEnumerable<string> ToTextParts(string? alarms) => Parse(alarms).Select(offset => offset.ToText());
+
+    /// <summary>
+    /// Builds DISPLAY alarms for a calendar component.
+    /// </summary>
+    /// <param name="alarms">The stored reminder list.</param>
+    /// <param name="summary">Text shown by the calendar client when the reminder fires.</param>
+    /// <param name="relation">
+    /// <see cref="TriggerRelation.Start"/> to trigger relative to DTSTART (events) or
+    /// <see cref="TriggerRelation.End"/> to trigger relative to DUE (todos).
+    /// </param>
+    public static IEnumerable<Alarm> BuildAlarms(string? alarms, string? summary, string relation)
+    {
+        var description = string.IsNullOrWhiteSpace(summary) ? "Reminder" : summary;
+
+        return Parse(alarms).Select(offset =>
+        {
+            var trigger = new Trigger()
+            {
+                Duration = offset.ToNegativeDuration(),
+                Related = relation,
+            };
+
+            // Ical.Net 5.2.1: setting Trigger.Related alone does not emit the RELATED=
+            // parameter (CalendarSerializer only reads the Parameters collection), so it
+            // must be set explicitly too. Only needed for END; START is the RFC default.
+            if (relation == TriggerRelation.End)
+            {
+                trigger.Parameters.Set("RELATED", relation);
+            }
+
+            // RFC 5545 3.6.6: a DISPLAY alarm must carry ACTION, TRIGGER and DESCRIPTION
+            return new Alarm()
+            {
+                Action = AlarmAction.Display,
+                Summary = description,
+                Description = description,
+                Trigger = trigger,
+            };
+        });
+    }
+}

--- a/LifelogBb/Views/Goals/Create.cshtml
+++ b/LifelogBb/Views/Goals/Create.cshtml
@@ -46,6 +46,10 @@
                         <input asp-for="EndDate" class="form-control form-control-lg" />
                         <span asp-validation-for="EndDate" class="text-danger"></span>
                     </div>
+                    <div class="form-group mb-3">
+                        @Html.EditorFor(model => model.Alarms, "Alarms")
+                        <span asp-validation-for="Alarms" class="text-danger"></span>
+                    </div>
                     <div class="mb-3 mt-3">
                         <label class="form-group form-check form-switch">
                             <input class="form-check-input" asp-for="IsCompleted" type="checkbox">
@@ -79,6 +83,7 @@
 }
 
 @section Scripts {
+    <script src="~/js/alarmeditor.js"></script>
     <script src="~/lib/tagify/tagify.min.js"></script>
     <script>
         new Tagify(document.querySelector('#Category'), {

--- a/LifelogBb/Views/Goals/Details.cshtml
+++ b/LifelogBb/Views/Goals/Details.cshtml
@@ -55,6 +55,12 @@
                             @Html.DisplayFor(model => model.EndDate)
                         </dd>
                         <dt class="col-sm-2">
+                            @Html.DisplayNameFor(model => model.Alarms)
+                        </dt>
+                        <dd class="col-sm-10">
+                            @Html.DisplayFor(model => model.Alarms, "Alarms")
+                        </dd>
+                        <dt class="col-sm-2">
                             @Html.DisplayNameFor(model => model.IsCompleted)
                         </dt>
                         <dd class="col-sm-10">

--- a/LifelogBb/Views/Goals/Edit.cshtml
+++ b/LifelogBb/Views/Goals/Edit.cshtml
@@ -46,6 +46,10 @@
                         <input asp-for="EndDate" class="form-control form-control-lg" />
                         <span asp-validation-for="EndDate" class="text-danger"></span>
                     </div>
+                    <div class="form-group mb-3">
+                        @Html.EditorFor(model => model.Alarms, "Alarms")
+                        <span asp-validation-for="Alarms" class="text-danger"></span>
+                    </div>
                     <div class="mb-3 mt-3">
                         <label class="form-group form-check form-switch">
                             <input class="form-check-input" asp-for="IsCompleted" type="checkbox">
@@ -80,6 +84,7 @@
 }
 
 @section Scripts {
+    <script src="~/js/alarmeditor.js"></script>
     <script src="~/lib/tagify/tagify.min.js"></script>
     <script>
         new Tagify(document.querySelector('#Category'), {

--- a/LifelogBb/Views/Habits/Create.cshtml
+++ b/LifelogBb/Views/Habits/Create.cshtml
@@ -35,6 +35,10 @@
                         @Html.EditorFor(model => model.RecurrenceRules, "RecurrenceRules")
                         <span asp-validation-for="RecurrenceRules" class="text-danger"></span>
                     </div>
+                    <div class="form-group mb-3">
+                        @Html.EditorFor(model => model.Alarms, "Alarms")
+                        <span asp-validation-for="Alarms" class="text-danger"></span>
+                    </div>
                     <div class="mb-3 mt-3">
                         <label class="form-group form-check form-switch">
                             <input class="form-check-input" asp-for="IsCompleted" type="checkbox">
@@ -70,6 +74,7 @@
 @section Scripts {
     <script src="~/lib/rrule/dist/es5/rrule.min.js"></script>
     <script src="~/js/rruleeditor.js"></script>
+    <script src="~/js/alarmeditor.js"></script>
 
     <script src="~/lib/tagify/tagify.min.js"></script>
     <script>

--- a/LifelogBb/Views/Habits/Details.cshtml
+++ b/LifelogBb/Views/Habits/Details.cshtml
@@ -43,6 +43,12 @@
                             @Html.DisplayFor(model => model.RecurrenceRules)
                         </dd>
                         <dt class="col-sm-2">
+                            @Html.DisplayNameFor(model => model.Alarms)
+                        </dt>
+                        <dd class="col-sm-10">
+                            @Html.DisplayFor(model => model.Alarms, "Alarms")
+                        </dd>
+                        <dt class="col-sm-2">
                             @Html.DisplayNameFor(model => model.IsCompleted)
                         </dt>
                         <dd class="col-sm-10">

--- a/LifelogBb/Views/Habits/Edit.cshtml
+++ b/LifelogBb/Views/Habits/Edit.cshtml
@@ -35,6 +35,10 @@
                         @Html.EditorFor(model => model.RecurrenceRules, "RecurrenceRules")
                         <span asp-validation-for="RecurrenceRules" class="text-danger"></span>
                     </div>
+                    <div class="form-group mb-3">
+                        @Html.EditorFor(model => model.Alarms, "Alarms")
+                        <span asp-validation-for="Alarms" class="text-danger"></span>
+                    </div>
                     <div class="mb-3 mt-3">
                         <label class="form-group form-check form-switch">
                             <input class="form-check-input" asp-for="IsCompleted" type="checkbox">
@@ -71,6 +75,7 @@
 @section Scripts {
     <script src="~/lib/rrule/dist/es5/rrule.min.js"></script>
     <script src="~/js/rruleeditor.js"></script>
+    <script src="~/js/alarmeditor.js"></script>
 
     <script src="~/lib/tagify/tagify.min.js"></script>
     <script>

--- a/LifelogBb/Views/Shared/DisplayTemplates/Alarms.cshtml
+++ b/LifelogBb/Views/Shared/DisplayTemplates/Alarms.cshtml
@@ -1,0 +1,6 @@
+@model string?
+
+@foreach (var reminder in LifelogBb.Utilities.AlarmHelper.ToTextParts(Model))
+{
+    <span class="badge text-bg-azure">@reminder</span>
+}

--- a/LifelogBb/Views/Shared/EditorTemplates/Alarms.cshtml
+++ b/LifelogBb/Views/Shared/EditorTemplates/Alarms.cshtml
@@ -1,0 +1,30 @@
+@model string?
+
+@*
+    Reminder list editor. The visible rows carry no name attribute and never post; the hidden
+    input below holds the serialized value ("-PT15M,-P1D") that the model binder picks up.
+    See wwwroot/js/alarmeditor.js.
+*@
+<div class="alarm-editor" data-alarm-editor data-alarm-max="@LifelogBb.Utilities.AlarmHelper.MaxAlarms">
+    <label for="Alarms" class="control-label mb-1">Reminders</label>
+    <input name="Alarms" id="Alarms" class="form-control form-control-lg" value="@Model" hidden />
+
+    <div data-alarm-rows></div>
+    <div data-alarm-empty class="text-secondary mb-2">No reminders.</div>
+
+    <div>
+        <button type="button" class="btn btn-primary" data-alarm-add><i class="fas fa-plus icon"></i> Add reminder</button>
+    </div>
+
+    <template data-alarm-template>
+        <div class="input-group mb-2" data-alarm-row>
+            <input type="number" class="form-control form-control-lg" min="1" max="9999" value="15" data-alarm-amount />
+            <select class="form-select form-select-lg" data-alarm-unit>
+                <option value="M">minutes before</option>
+                <option value="H">hours before</option>
+                <option value="D">days before</option>
+            </select>
+            <button type="button" class="btn btn-lg btn-outline-danger" data-alarm-remove title="Remove reminder"><i class="fas fa-trash icon"></i></button>
+        </div>
+    </template>
+</div>

--- a/LifelogBb/Views/Todos/Create.cshtml
+++ b/LifelogBb/Views/Todos/Create.cshtml
@@ -32,6 +32,10 @@
                         <span asp-validation-for="DueDate" class="text-danger"></span>
                     </div>
                     <div class="form-group mb-3">
+                        @Html.EditorFor(model => model.Alarms, "Alarms")
+                        <span asp-validation-for="Alarms" class="text-danger"></span>
+                    </div>
+                    <div class="form-group mb-3">
                         <label asp-for="Progress" class="control-label mb-1"></label>
                         <input asp-for="Progress" class="form-control form-control-lg" />
                         <span asp-validation-for="Progress" class="text-danger"></span>
@@ -80,6 +84,7 @@
 }
 
 @section Scripts {
+    <script src="~/js/alarmeditor.js"></script>
     <script src="~/lib/tagify/tagify.min.js"></script>
     <script>
         new Tagify(document.querySelector('#Category'), {

--- a/LifelogBb/Views/Todos/Details.cshtml
+++ b/LifelogBb/Views/Todos/Details.cshtml
@@ -37,6 +37,12 @@
                             @Html.DisplayFor(model => model.DueDate)
                         </dd>
                         <dt class="col-sm-2">
+                            @Html.DisplayNameFor(model => model.Alarms)
+                        </dt>
+                        <dd class="col-sm-10">
+                            @Html.DisplayFor(model => model.Alarms, "Alarms")
+                        </dd>
+                        <dt class="col-sm-2">
                             @Html.DisplayNameFor(model => model.Progress)
                         </dt>
                         <dd class="col-sm-10">

--- a/LifelogBb/Views/Todos/Edit.cshtml
+++ b/LifelogBb/Views/Todos/Edit.cshtml
@@ -32,6 +32,10 @@
                         <span asp-validation-for="DueDate" class="text-danger"></span>
                     </div>
                     <div class="form-group mb-3">
+                        @Html.EditorFor(model => model.Alarms, "Alarms")
+                        <span asp-validation-for="Alarms" class="text-danger"></span>
+                    </div>
+                    <div class="form-group mb-3">
                         <label asp-for="Progress" class="control-label mb-1"></label>
                         <input asp-for="Progress" class="form-control form-control-lg" />
                         <span asp-validation-for="Progress" class="text-danger"></span>
@@ -81,6 +85,7 @@
 }
 
 @section Scripts {
+    <script src="~/js/alarmeditor.js"></script>
     <script src="~/lib/tagify/tagify.min.js"></script>
     <script>
         new Tagify(document.querySelector('#Category'), {

--- a/LifelogBb/wwwroot/js/alarmeditor.js
+++ b/LifelogBb/wwwroot/js/alarmeditor.js
@@ -1,0 +1,84 @@
+// Repeatable "remind me X before" row editor. Serializes to a comma separated list of negative
+// ISO-8601 durations (e.g. "-PT15M,-P1D") into the editor's hidden input. Scoped to each
+// [data-alarm-editor] container instead of using global ids, so more than one could exist on a page.
+
+document.addEventListener("DOMContentLoaded", function () {
+  var editors = document.querySelectorAll("[data-alarm-editor]");
+
+  editors.forEach(function (editor) {
+    var hiddenInput = editor.querySelector("#Alarms") || editor.querySelector('input[name="Alarms"]');
+    var rowsContainer = editor.querySelector("[data-alarm-rows]");
+    var emptyText = editor.querySelector("[data-alarm-empty]");
+    var addButton = editor.querySelector("[data-alarm-add]");
+    var template = editor.querySelector("[data-alarm-template]");
+    var maxAlarms = parseInt(editor.getAttribute("data-alarm-max"), 10) || 10;
+
+    function parseValue(value) {
+      if (!value) return [];
+      return value
+        .split(",")
+        .map(function (part) { return part.trim(); })
+        .filter(function (part) { return part.length > 0; })
+        .map(function (part) {
+          var match = /^-P(?:T(\d{1,4})([HM])|(\d{1,4})(D))$/.exec(part);
+          if (!match) return null;
+          var amount = match[1] || match[3];
+          var unit = match[2] || match[4];
+          return { amount: parseInt(amount, 10), unit: unit };
+        })
+        .filter(function (entry) { return entry !== null; });
+    }
+
+    function updateEmptyState() {
+      var hasRows = rowsContainer.querySelectorAll("[data-alarm-row]").length > 0;
+      emptyText.hidden = hasRows;
+      addButton.hidden = rowsContainer.querySelectorAll("[data-alarm-row]").length >= maxAlarms;
+    }
+
+    function serialize() {
+      var rows = rowsContainer.querySelectorAll("[data-alarm-row]");
+      var parts = [];
+      rows.forEach(function (row) {
+        var amount = parseInt(row.querySelector("[data-alarm-amount]").value, 10);
+        var unit = row.querySelector("[data-alarm-unit]").value;
+        if (!amount || amount <= 0) return;
+        parts.push(unit === "D" ? ("-P" + amount + "D") : ("-PT" + amount + unit));
+      });
+      hiddenInput.value = parts.join(",");
+      updateEmptyState();
+    }
+
+    function addRow(amount, unit) {
+      if (rowsContainer.querySelectorAll("[data-alarm-row]").length >= maxAlarms) return;
+
+      var fragment = template.content.cloneNode(true);
+      var row = fragment.querySelector("[data-alarm-row]");
+      var amountInput = row.querySelector("[data-alarm-amount]");
+      var unitSelect = row.querySelector("[data-alarm-unit]");
+      var removeButton = row.querySelector("[data-alarm-remove]");
+
+      amountInput.value = amount || 15;
+      unitSelect.value = unit || "M";
+
+      amountInput.addEventListener("input", serialize);
+      unitSelect.addEventListener("change", serialize);
+      removeButton.addEventListener("click", function () {
+        row.remove();
+        serialize();
+      });
+
+      rowsContainer.appendChild(row);
+    }
+
+    addButton.addEventListener("click", function () {
+      addRow(15, "M");
+      serialize();
+    });
+
+    // Seed rows from the hidden input's initial value
+    parseValue(hiddenInput.value).forEach(function (entry) {
+      addRow(entry.amount, entry.unit);
+    });
+    updateEmptyState();
+  });
+});

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ All **data** is stored in a single **SQLite database** for full control and port
 * 🌄 Bucket list and Vision board
 * 📜 Quotes
 * 🛠️ RESTful API for all routes, Swagger UI
-* 📅 iCal feeds: Todo for Todos and Goals, Event for Habits (Time boxing/blocking)
+* 📅 iCal feeds: Todo for Todos and Goals, Event for Habits (Time boxing/blocking), with configurable DISPLAY reminders
 * ⚙️ Settings
 * 🖼 [Tabler](https://tabler.io/) UI
 * 🤖 MCP Server and optional OpenAI compatible Chat (supports local LLMs)

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,6 @@ ToDos and Features for LifelogBB.
 
 ### Todo
 
-- [ ] iCal Alarms
 - [ ] Publish images to GHCR and/or Dockerhub
 - [ ] Notifications: Mail, Telegram, ...
 
@@ -26,6 +25,8 @@ ToDos and Features for LifelogBB.
   - VTODO for Goals/Todos
   - VEVENT for Habits (Time Boxing/Blocking)
     - RRULE ui [rrule.js](https://jakubroztocil.github.io/rrule/), [rrule-tool](https://icalendar.org/rrule-tool.html), [rrule-generator](https://freetools.textmagic.com/rrule-generator)    
+- [x] iCal Alarms
+  - DISPLAY reminders (X minutes/hours/days before), multiple per entry
 - [x] Weights in metric system and imperial units (no conversion)
 - [x] Settings (Units, Start of week, ...)
 - [x] Tags, Category


### PR DESCRIPTION
## Summary

- Closes the "iCal Alarms" TODO item: adds RFC 5545 `VALARM` (`ACTION:DISPLAY`) reminders to the existing Habit/Todo/Goal iCal feeds — no `AUDIO`/`EMAIL`, no absolute triggers, per RFC 5545 §3.6.6.
- Users can define multiple "remind me X minutes/hours/days before" entries per entry via a new repeatable UI component (`Views/Shared/EditorTemplates/Alarms.cshtml` + `wwwroot/js/alarmeditor.js`), stored as a single nullable `Alarms` column (CSV of negative ISO-8601 durations, e.g. `-PT15M,-P1D`) — same pattern as the existing `Tags`/`RecurrenceRules` fields.
- Habits (`VEVENT`) trigger relative to `DTSTART` (RFC default, `RELATED` omitted). Todos/Goals (`VTODO`) trigger relative to `DUE` (`RELATED=END`), which required also mapping `DueDate`/`EndDate` onto the previously-unexported `Due` property on both feeds — reminders are only emitted when that anchor date is present.
- New `LifelogBb/Utilities/AlarmHelper.cs` parses/validates/serializes the list and builds Ical.Net `Alarm` objects. Found and worked around an Ical.Net 5.2.1 quirk where `Trigger.Related` alone doesn't emit the `RELATED=` parameter — it also has to be set via `Trigger.Parameters`.
- New EF Core migration `IcalAlarms` adds the nullable `Alarms` column to `Habits`, `Todos`, `Goals`.

## Test plan

- [x] `dotnet build` — clean, 0 warnings/errors
- [x] Ran the app locally against a seeded dev database; added/removed reminder rows in the browser UI, saved, reloaded — values round-tripped correctly; Details page renders reminder badges
- [x] Fetched `/Habits/Feed`, `/Todos/Feed`, `/Goals/Feed` and inspected raw ICS output: confirmed correct `VALARM` blocks, correct `TRIGGER;RELATED=END` on Todos/Goals, and confirmed a Todo with reminders but no due date correctly emits **no** alarm
- [ ] Subscribe from a real calendar client (Thunderbird / iOS Calendar) to confirm the notification actually fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)