### PR TITLE
Add strength training plans, workout capture, and analytics overhaul

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "lifelogbb",
+      "runtimeExecutable": "dotnet",
+      "runtimeArgs": ["run", "--project", "LifelogBb", "--urls", "http://localhost:5290"],
+      "port": 5290
+    }
+  ]
+}

--- a/LifelogBb/ApiControllers/TrainingPlansApiController.cs
+++ b/LifelogBb/ApiControllers/TrainingPlansApiController.cs
@@ -19,6 +19,10 @@ namespace LifelogBb.ApiControllers
         }
 
         // POST: api/trainingplans/5/copy
+        // No [ValidateAntiForgeryToken], matching every other write endpoint on this generic API family
+        // (see AuthenticationController) -- it must stay callable from Swagger/bearer-token clients that
+        // never hold an antiforgery token. Cookie-authenticated cross-site requests are mitigated by the
+        // default SameSite=Lax auth cookie configured in Program.cs.
         [HttpPost("{id}/copy")]
         public async Task<ActionResult<TrainingPlanOutput>> Copy(long id, [FromBody] CopyTrainingPlanRequest? request)
         {

--- a/LifelogBb/ApiControllers/TrainingPlansApiController.cs
+++ b/LifelogBb/ApiControllers/TrainingPlansApiController.cs
@@ -1,0 +1,32 @@
+using LifelogBb.ApiDTOs.TrainingPlans;
+using LifelogBb.ApiServices;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LifelogBb.ApiControllers
+{
+    [Route("api/trainingplans")]
+    [ApiController]
+    public class TrainingPlansApiController : BaseCRUDController<TrainingPlansService, TrainingPlanInput, TrainingPlanOutput>
+    {
+        public TrainingPlansApiController(TrainingPlansService service) : base(service)
+        {
+        }
+
+        public class CopyTrainingPlanRequest
+        {
+            public DateTime? Date { get; set; }
+            public string? Name { get; set; }
+        }
+
+        // POST: api/trainingplans/5/copy
+        [HttpPost("{id}/copy")]
+        public async Task<ActionResult<TrainingPlanOutput>> Copy(long id, [FromBody] CopyTrainingPlanRequest? request)
+        {
+            var result = await _service.CopyPlan(id, request?.Date, request?.Name);
+            if (result == null)
+                return NotFound();
+
+            return Ok(result);
+        }
+    }
+}

--- a/LifelogBb/ApiDTOs/AutoMapperProfile.cs
+++ b/LifelogBb/ApiDTOs/AutoMapperProfile.cs
@@ -8,6 +8,7 @@ using LifelogBb.ApiDTOs.Quotes;
 using LifelogBb.ApiDTOs.Todos;
 using LifelogBb.ApiDTOs.Habits;
 using LifelogBb.ApiDTOs.Goals;
+using LifelogBb.ApiDTOs.TrainingPlans;
 
 namespace LifelogBb.DTOs
 {
@@ -29,8 +30,17 @@ namespace LifelogBb.DTOs
             CreateMap<EnduranceTraining, EnduranceTrainingOutput>();
 
             // StrengthTrainings
-            CreateMap<StrengthTrainingInput, StrengthTraining>();
+            CreateMap<StrengthTrainingInput, StrengthTraining>()
+                .ForMember(dest => dest.Date, opt => opt.MapFrom(src => (src.Date ?? DateTime.UtcNow).Date));
             CreateMap<StrengthTraining, StrengthTrainingOutput>();
+
+            // TrainingPlans - Sets are built/replaced explicitly by TrainingPlansService, not by AutoMapper.
+            CreateMap<TrainingPlanInput, TrainingPlan>()
+                .ForMember(dest => dest.Sets, opt => opt.Ignore());
+            CreateMap<TrainingPlanSetInput, TrainingPlanSet>();
+            CreateMap<TrainingPlan, TrainingPlanOutput>()
+                .ForMember(dest => dest.Sets, opt => opt.MapFrom(src => src.Sets.OrderBy(s => s.SortOrder)));
+            CreateMap<TrainingPlanSet, TrainingPlanSetOutput>();
 
             // Quotes
             CreateMap<QuoteInput, Quote>();

--- a/LifelogBb/ApiDTOs/StrengthTrainings/StrengthTrainingInput.cs
+++ b/LifelogBb/ApiDTOs/StrengthTrainings/StrengthTrainingInput.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
+﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.ComponentModel.DataAnnotations;
 
 namespace LifelogBb.ApiDTOs.StrengthTrainings
@@ -15,5 +16,14 @@ namespace LifelogBb.ApiDTOs.StrengthTrainings
 
         [Range(1, 5)]
         public int Rating { get; set; }
+
+        [Description("The day this set was trained. Defaults to today when omitted.")]
+        public DateTime? Date { get; set; }
+
+        [Description("Id of the training plan (template or day plan) this set belongs to, if any.")]
+        public long? TrainingPlanId { get; set; }
+
+        [Description("Id of the specific planned set this entry fulfills, if any.")]
+        public long? TrainingPlanSetId { get; set; }
     }
 }

--- a/LifelogBb/ApiDTOs/TrainingPlans/TrainingPlanInput.cs
+++ b/LifelogBb/ApiDTOs/TrainingPlans/TrainingPlanInput.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+namespace LifelogBb.ApiDTOs.TrainingPlans
+{
+    public class TrainingPlanInput
+    {
+        public string? Name { get; set; }
+
+        public string? Description { get; set; }
+
+        [Description("Leave empty for a reusable base/template plan. Set a date to make this a concrete plan for that day.")]
+        public DateTime? Date { get; set; }
+
+        public bool IsArchived { get; set; }
+
+        [Description("The planned sets in the order they should be performed. This fully replaces the plan's sets on update -- any set not included here is removed, and links from previously logged strength trainings to a removed set are cleared.")]
+        public List<TrainingPlanSetInput> Sets { get; set; } = new();
+    }
+}

--- a/LifelogBb/ApiDTOs/TrainingPlans/TrainingPlanOutput.cs
+++ b/LifelogBb/ApiDTOs/TrainingPlans/TrainingPlanOutput.cs
@@ -1,0 +1,23 @@
+using LifelogBb.Interfaces.DTOs;
+
+namespace LifelogBb.ApiDTOs.TrainingPlans
+{
+    public class TrainingPlanOutput : IBaseOutput
+    {
+        public long Id { get; set; }
+
+        public string Name { get; set; } = string.Empty;
+
+        public string? Description { get; set; }
+
+        public DateTime? Date { get; set; }
+
+        public bool IsArchived { get; set; }
+
+        public List<TrainingPlanSetOutput> Sets { get; set; } = new();
+
+        public DateTime CreatedAt { get; set; }
+
+        public DateTime UpdatedAt { get; set; }
+    }
+}

--- a/LifelogBb/ApiDTOs/TrainingPlans/TrainingPlanSetInput.cs
+++ b/LifelogBb/ApiDTOs/TrainingPlans/TrainingPlanSetInput.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+namespace LifelogBb.ApiDTOs.TrainingPlans
+{
+    public class TrainingPlanSetInput
+    {
+        [Description("Name of the exercise. Use the same spelling as previous entries so progress can be tracked.")]
+        public string? Exercise { get; set; }
+
+        [Description("Planned number of repetitions for this set.")]
+        public int Reps { get; set; }
+
+        [Description("Planned weight for this set.")]
+        public double Weight { get; set; }
+
+        public string? Notes { get; set; }
+    }
+}

--- a/LifelogBb/ApiDTOs/TrainingPlans/TrainingPlanSetOutput.cs
+++ b/LifelogBb/ApiDTOs/TrainingPlans/TrainingPlanSetOutput.cs
@@ -1,26 +1,22 @@
-﻿using LifelogBb.Interfaces.DTOs;
+using LifelogBb.Interfaces.DTOs;
 
-namespace LifelogBb.ApiDTOs.StrengthTrainings
+namespace LifelogBb.ApiDTOs.TrainingPlans
 {
-    public class StrengthTrainingOutput : IBaseOutput
+    public class TrainingPlanSetOutput : IBaseOutput
     {
         public long Id { get; set; }
 
+        public long TrainingPlanId { get; set; }
+
         public string Exercise { get; set; } = string.Empty;
+
+        public int SortOrder { get; set; }
 
         public int Reps { get; set; }
 
         public double Weight { get; set; }
 
         public string? Notes { get; set; }
-
-        public int Rating { get; set; }
-
-        public DateTime Date { get; set; }
-
-        public long? TrainingPlanId { get; set; }
-
-        public long? TrainingPlanSetId { get; set; }
 
         public DateTime CreatedAt { get; set; }
 

--- a/LifelogBb/ApiServices/ChatToolRegistry.cs
+++ b/LifelogBb/ApiServices/ChatToolRegistry.cs
@@ -8,6 +8,7 @@ using LifelogBb.ApiDTOs.Journals;
 using LifelogBb.ApiDTOs.Quotes;
 using LifelogBb.ApiDTOs.StrengthTrainings;
 using LifelogBb.ApiDTOs.Todos;
+using LifelogBb.ApiDTOs.TrainingPlans;
 using LifelogBb.ApiDTOs.Weights;
 using LifelogBb.Interfaces;
 using LifelogBb.Models.Entities;
@@ -56,6 +57,8 @@ namespace LifelogBb.ApiServices
                 CreateToolParameters()));
             tools.Add(CreateToolDefinition("GetAllEnduranceTrainings", "Get recent endurance training data ordered by most recently updated first. Results default to 25 records and are capped at 50.",
                 CreateToolParameters()));
+            tools.Add(CreateToolDefinition("GetAllTrainingPlans", "Get recent strength training plans (base plans and day plans), including their planned sets, ordered by most recently created first. Results default to 25 records and are capped at 50.",
+                CreateToolParameters()));
 
             return tools;
         }
@@ -95,6 +98,9 @@ namespace LifelogBb.ApiServices
                     "GetAllQuotes" => await GetAllFromRepository<Quote, QuoteOutput>(filter, limit),
                     "GetAllStrengthTrainings" => await GetAllFromRepository<StrengthTraining, StrengthTrainingOutput>(filter, limit),
                     "GetAllEnduranceTrainings" => await GetAllFromRepository<EnduranceTraining, EnduranceTrainingOutput>(filter, limit),
+                    // TrainingPlans have a Sets child collection the generic GetAllFromRepository does not
+                    // Include(), so this goes through TrainingPlansService instead, which does.
+                    "GetAllTrainingPlans" => await GetAllTrainingPlans(filter, limit),
                     _ => throw new InvalidOperationException($"Unknown tool: {toolName}")
                 };
 
@@ -104,6 +110,25 @@ namespace LifelogBb.ApiServices
             {
                 return JsonSerializer.Serialize(new { error = ex.Message });
             }
+        }
+
+        private async Task<object> GetAllTrainingPlans(string? filter, int limit)
+        {
+            var service = _serviceProvider.GetRequiredService<TrainingPlansService>();
+            // Take one extra record so the response can tell the model when more matching data exists,
+            // same as GetAllFromRepository below.
+            var result = await service.GetAll(filter, $"{nameof(TrainingPlan.CreatedAt)}_desc", limit + 1);
+            var entries = (result.Value ?? Enumerable.Empty<TrainingPlanOutput>()).ToList();
+
+            var truncated = entries.Count > limit;
+            var items = truncated ? entries.Take(limit).ToList() : entries;
+
+            return new
+            {
+                items,
+                limit,
+                truncated
+            };
         }
 
         private async Task<object> GetAllFromRepository<TEntity, TOutput>(string? filter, int limit)

--- a/LifelogBb/ApiServices/StrengthTrainingsService.cs
+++ b/LifelogBb/ApiServices/StrengthTrainingsService.cs
@@ -11,5 +11,9 @@ namespace LifelogBb.ApiServices
         public StrengthTrainingsService(IRepository<StrengthTraining> repository, IMapper mapper) : base(repository, mapper)
         {
         }
+
+        // A strength training entry carries the day it was trained, which can differ from the day it
+        // was logged (e.g. retroactive entry, or a day plan worked through the next morning).
+        protected override string DefaultSortOrder => $"{nameof(StrengthTraining.Date)}_desc";
     }
 }

--- a/LifelogBb/ApiServices/TrainingPlansService.cs
+++ b/LifelogBb/ApiServices/TrainingPlansService.cs
@@ -1,0 +1,145 @@
+using AutoMapper;
+using LifelogBb.ApiDTOs.TrainingPlans;
+using LifelogBb.Interfaces;
+using LifelogBb.Models.Entities;
+using LifelogBb.Utilities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace LifelogBb.ApiServices
+{
+    // The generic BaseCRUDService/EntityRepository stack does no .Include(), so a plan's Sets would
+    // never be loaded. This service overrides every read/write operation to load and manage the Sets
+    // child collection explicitly, while still implementing IBaseCRUDService so BaseCRUDController and
+    // BaseTool (API + MCP) work unmodified.
+    public class TrainingPlansService : BaseCRUDService<TrainingPlan, TrainingPlanInput, TrainingPlanOutput>
+    {
+        public TrainingPlansService(IRepository<TrainingPlan> repository, IMapper mapper) : base(repository, mapper)
+        {
+        }
+
+        protected override string DefaultSortOrder => $"{nameof(TrainingPlan.CreatedAt)}_desc";
+
+        public override async Task<ActionResult<IEnumerable<TrainingPlanOutput>>> GetAll()
+        {
+            var entities = await _repository.Query.Include(p => p.Sets).ToListAsync();
+            return _mapper.Map<List<TrainingPlanOutput>>(entities);
+        }
+
+        public override async Task<ActionResult<IEnumerable<TrainingPlanOutput>>> GetAll(string? filterJson, string? sortOrder = null, int? limit = null)
+        {
+            sortOrder = string.IsNullOrWhiteSpace(sortOrder) ? DefaultSortOrder : sortOrder;
+
+            if (limit is < 1)
+                throw new ArgumentException($"Limit must be at least 1 but was {limit}.");
+
+            var query = _repository.Query
+                .Include(p => p.Sets)
+                .FilterByGroup<TrainingPlan>(filterJson, throwOnInvalidFilter: true)
+                .SortByName(sortOrder, DefaultSortOrder);
+
+            IQueryable<TrainingPlan> limited = query;
+            if (limit.HasValue)
+                limited = limited.Take(limit.Value);
+
+            var entities = await limited.ToListAsync();
+            return _mapper.Map<List<TrainingPlanOutput>>(entities);
+        }
+
+        public override async Task<TrainingPlanOutput> GetById(long id)
+        {
+            var entity = await _repository.Query.Include(p => p.Sets).FirstOrDefaultAsync(p => p.Id == id);
+            return _mapper.Map<TrainingPlanOutput>(entity);
+        }
+
+        public override async Task<TrainingPlanOutput> Create(TrainingPlanInput inputModel)
+        {
+            var plan = _mapper.Map<TrainingPlan>(inputModel);
+            plan.SetCreateFields();
+            plan.Sets = BuildSets(inputModel.Sets, plan);
+
+            _repository.Insert(plan);
+            await _repository.Context.SaveChangesAsync();
+
+            return _mapper.Map<TrainingPlanOutput>(plan);
+        }
+
+        public override async Task<TrainingPlanOutput> Update(long id, TrainingPlanInput inputModel)
+        {
+            var plan = await _repository.Query.Include(p => p.Sets).FirstOrDefaultAsync(p => p.Id == id);
+            if (plan == null)
+                throw new Exception("Invalid id");
+
+            _mapper.Map(inputModel, plan);
+            plan.SetUpdateFields();
+
+            // Full replace: any StrengthTraining rows that pointed at a removed set are cleared to
+            // null via the SetNull FK behavior configured in LifelogBbContext, not deleted.
+            _repository.Context.TrainingPlanSets.RemoveRange(plan.Sets);
+            plan.Sets = BuildSets(inputModel.Sets, plan);
+
+            await _repository.Context.SaveChangesAsync();
+            return _mapper.Map<TrainingPlanOutput>(plan);
+        }
+
+        public async Task<TrainingPlanOutput?> CopyPlan(long sourceId, DateTime? date, string? name)
+        {
+            var source = await _repository.Query.Include(p => p.Sets).FirstOrDefaultAsync(p => p.Id == sourceId);
+            if (source == null)
+                return null;
+
+            var copy = new TrainingPlan
+            {
+                Name = string.IsNullOrWhiteSpace(name) ? $"{source.Name} (Copy)" : name,
+                Description = source.Description,
+                Date = date?.Date,
+                IsArchived = false
+            };
+            copy.SetCreateFields();
+
+            copy.Sets = source.Sets
+                .OrderBy(s => s.SortOrder)
+                .Select((s, index) =>
+                {
+                    var set = new TrainingPlanSet
+                    {
+                        Exercise = s.Exercise,
+                        SortOrder = index,
+                        Reps = s.Reps,
+                        Weight = s.Weight,
+                        Notes = s.Notes,
+                        TrainingPlan = copy
+                    };
+                    set.SetCreateFields();
+                    return set;
+                })
+                .ToList();
+
+            _repository.Insert(copy);
+            await _repository.Context.SaveChangesAsync();
+
+            return _mapper.Map<TrainingPlanOutput>(copy);
+        }
+
+        private static List<TrainingPlanSet> BuildSets(List<TrainingPlanSetInput> inputs, TrainingPlan plan)
+        {
+            var sets = new List<TrainingPlanSet>();
+            for (var index = 0; index < inputs.Count; index++)
+            {
+                var input = inputs[index];
+                var set = new TrainingPlanSet
+                {
+                    Exercise = input.Exercise ?? string.Empty,
+                    SortOrder = index,
+                    Reps = input.Reps,
+                    Weight = input.Weight,
+                    Notes = input.Notes,
+                    TrainingPlan = plan
+                };
+                set.SetCreateFields();
+                sets.Add(set);
+            }
+            return sets;
+        }
+    }
+}

--- a/LifelogBb/Controllers/HomeController.cs
+++ b/LifelogBb/Controllers/HomeController.cs
@@ -45,7 +45,7 @@ namespace LifelogBb.Controllers
             var enduranceTraining = await _context.EnduranceTrainings.OrderByDescending(o => o.CreatedAt).Take(1).FirstOrDefaultAsync();
             model.LastEnduranceTraining = enduranceTraining;
 
-            var strengthTraining = await _context.StrengthTrainings.OrderByDescending(o => o.CreatedAt).Take(1).FirstOrDefaultAsync();
+            var strengthTraining = await _context.StrengthTrainings.OrderByDescending(o => o.Date).ThenByDescending(o => o.CreatedAt).Take(1).FirstOrDefaultAsync();
             model.LastStrengthTraining = strengthTraining;
 
             var randomBucketList = await _context.BucketLists.OrderBy(r => EF.Functions.Random()).Take(1).FirstOrDefaultAsync();
@@ -135,8 +135,8 @@ namespace LifelogBb.Controllers
                 .ThenBy(h => h.Name)
                 .ToListAsync();
             model.StrengthTrainings = await _context.StrengthTrainings
-                .Where(s => s.CreatedAt >= queryStart && s.CreatedAt < queryEndExclusive)
-                .OrderByDescending(s => s.CreatedAt)
+                .Where(s => s.Date >= queryStart && s.Date < queryEndExclusive)
+                .OrderByDescending(s => s.Date)
                 .ToListAsync();
             model.EnduranceTrainings = await _context.EnduranceTrainings
                 .Where(e => e.CreatedAt >= queryStart && e.CreatedAt < queryEndExclusive)

--- a/LifelogBb/Controllers/StrengthTrainingsController.cs
+++ b/LifelogBb/Controllers/StrengthTrainingsController.cs
@@ -23,7 +23,7 @@ namespace LifelogBb.Controllers
         public async Task<IActionResult> Index()
         {
             var all = await _context.StrengthTrainings
-                .OrderByDescending(s => s.CreatedAt)
+                .OrderByDescending(s => s.Date).ThenByDescending(s => s.CreatedAt)
                 .ToListAsync();
 
             var personalRecords = all
@@ -71,7 +71,7 @@ namespace LifelogBb.Controllers
 
             var trainings = from s in _context.StrengthTrainings select s;
             trainings = trainings.FilterByGroup(filter);
-            trainings = trainings.SortByName(sortOrder, $"{nameof(StrengthTraining.CreatedAt)}_desc");
+            trainings = trainings.SortByName(sortOrder, $"{nameof(StrengthTraining.Date)}_desc");
 
             var config = Config.GetConfig(_context);
             var list = await PaginatedList<StrengthTraining>.CreateAsync(trainings.AsNoTracking(), pageNumber ?? 1, config.StrengthTrainingPageSize);
@@ -79,11 +79,18 @@ namespace LifelogBb.Controllers
         }
 
         // GET: StrengthTrainings/Graph
-        public IActionResult Graph(string? exercise)
+        public async Task<IActionResult> Graph(string? exercise)
         {
-            return View("Graph", exercise);
+            var exercises = await _context.StrengthTrainings.Select(s => s.Exercise).Distinct().OrderBy(e => e).ToListAsync();
+            var model = new StrengthTrainingGraphViewModel
+            {
+                Exercises = exercises,
+                SelectedExercise = !string.IsNullOrEmpty(exercise) && exercises.Contains(exercise) ? exercise : null
+            };
+            return View("Graph", model);
         }
 
+        // Kept for backward compatibility with existing links; unused by the current Graph view.
         public async Task<IActionResult> GraphGet(string? exercise)
         {
             var strengthTrainings = from st in _context.StrengthTrainings select st;
@@ -93,7 +100,113 @@ namespace LifelogBb.Controllers
                 strengthTrainings = strengthTrainings.Where(s => s.Exercise == exercise);
             }
 
-            return Json(await strengthTrainings.OrderBy(o => o.CreatedAt).ToListAsync());
+            return Json(await strengthTrainings.OrderBy(o => o.Date).ToListAsync());
+        }
+
+        // GET: StrengthTrainings/GraphExerciseData
+        // One aggregated point per training day instead of one point per set -- a set-level bar chart
+        // over the whole history is unreadable once more than a handful of sessions exist.
+        public async Task<IActionResult> GraphExerciseData(string exercise, DateTime? from)
+        {
+            var query = _context.StrengthTrainings.Where(s => s.Exercise == exercise);
+            if (from.HasValue)
+            {
+                query = query.Where(s => s.Date >= from.Value.Date);
+            }
+
+            var sets = await query.ToListAsync();
+
+            var days = sets
+                .GroupBy(s => s.Date.Date)
+                .OrderBy(g => g.Key)
+                .Select(g => new
+                {
+                    date = g.Key.ToString("yyyy-MM-dd"),
+                    topWeight = g.Max(s => s.Weight),
+                    est1Rm = Math.Round(g.Max(s => s.Weight * (1 + s.Reps / 30.0)), 1),
+                    volume = g.Sum(s => s.Reps * s.Weight),
+                    sets = g.Count(),
+                    totalReps = g.Sum(s => s.Reps)
+                })
+                .ToList();
+
+            return Json(new { exercise, days });
+        }
+
+        // GET: StrengthTrainings/GraphOverviewData
+        public async Task<IActionResult> GraphOverviewData(DateTime? from)
+        {
+            var query = _context.StrengthTrainings.AsQueryable();
+            if (from.HasValue)
+            {
+                query = query.Where(s => s.Date >= from.Value.Date);
+            }
+
+            var sets = await query.ToListAsync();
+            var startOfWeek = Config.GetConfig(_context).StartOfWeek;
+
+            DateTime WeekStart(DateTime date)
+            {
+                var diff = (7 + (date.DayOfWeek - startOfWeek)) % 7;
+                return date.Date.AddDays(-diff);
+            }
+
+            var days = sets
+                .GroupBy(s => s.Date.Date)
+                .OrderBy(g => g.Key)
+                .Select(g => new
+                {
+                    date = g.Key.ToString("yyyy-MM-dd"),
+                    volume = g.Sum(s => s.Reps * s.Weight),
+                    sets = g.Count(),
+                    exercises = g.Select(s => s.Exercise).Distinct().Count()
+                })
+                .ToList();
+
+            var weeks = sets
+                .GroupBy(s => WeekStart(s.Date))
+                .OrderBy(g => g.Key)
+                .Select(g => new
+                {
+                    weekStart = g.Key.ToString("yyyy-MM-dd"),
+                    volume = g.Sum(s => s.Reps * s.Weight),
+                    trainingDays = g.Select(s => s.Date.Date).Distinct().Count(),
+                    sets = g.Count()
+                })
+                .ToList();
+
+            return Json(new { days, weeks });
+        }
+
+        // GET: StrengthTrainings/Sessions
+        public async Task<IActionResult> Sessions(DateTime? from)
+        {
+            var query = _context.StrengthTrainings.AsQueryable();
+            if (from.HasValue)
+            {
+                query = query.Where(s => s.Date >= from.Value.Date);
+            }
+
+            var sets = await query.Include(s => s.TrainingPlan).ToListAsync();
+
+            var sessions = sets
+                .GroupBy(s => s.Date.Date)
+                .OrderByDescending(g => g.Key)
+                .Select(g => new StrengthTrainingSession
+                {
+                    Date = g.Key,
+                    SetCount = g.Count(),
+                    Volume = g.Sum(s => s.Reps * s.Weight),
+                    Exercises = g.Select(s => s.Exercise).Distinct().OrderBy(e => e).ToList(),
+                    TrainingPlanId = g.Select(s => s.TrainingPlanId).FirstOrDefault(id => id != null),
+                    TrainingPlanName = g.Select(s => s.TrainingPlan).FirstOrDefault(p => p != null)?.Name,
+                    PlannedSetCount = g.Select(s => s.TrainingPlan).FirstOrDefault(p => p != null)?.Id is long planId
+                        ? _context.TrainingPlanSets.Count(ps => ps.TrainingPlanId == planId)
+                        : (int?)null
+                })
+                .ToList();
+
+            return View(sessions);
         }
 
         // GET: StrengthTrainings/Details/5
@@ -119,14 +232,19 @@ namespace LifelogBb.Controllers
         {
             var exercises = await _context.StrengthTrainings.Select(s => s.Exercise).Distinct().ToListAsync();
             ViewData["ExerciseList"] = string.Join(",", exercises);
-            return View();
+            return View(new StrengthTraining { Date = DateTime.UtcNow.Date });
         }
 
         // POST: StrengthTrainings/Create
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Create([Bind("Exercise,Reps,Weight,Notes,Rating")] StrengthTraining strengthTraining)
+        public async Task<IActionResult> Create([Bind("Exercise,Reps,Weight,Notes,Rating,Date")] StrengthTraining strengthTraining)
         {
+            if (strengthTraining.Date == default)
+            {
+                strengthTraining.Date = DateTime.UtcNow.Date;
+            }
+
             if (ModelState.IsValid)
             {
                 strengthTraining.SetCreateFields();
@@ -160,7 +278,7 @@ namespace LifelogBb.Controllers
         // POST: StrengthTrainings/Edit/5
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Edit(long id, [Bind("Exercise,Reps,Weight,Notes,Rating,Id")] EditStrengthTrainingViewModel strengthTrainingViewModel)
+        public async Task<IActionResult> Edit(long id, [Bind("Exercise,Reps,Weight,Notes,Rating,Date,Id")] EditStrengthTrainingViewModel strengthTrainingViewModel)
         {
             if (id != strengthTrainingViewModel.Id)
             {

--- a/LifelogBb/Controllers/TrainingPlansController.cs
+++ b/LifelogBb/Controllers/TrainingPlansController.cs
@@ -1,0 +1,405 @@
+using System.Text.Json;
+using AutoMapper;
+using LifelogBb.ApiServices;
+using LifelogBb.Models;
+using LifelogBb.Models.Entities;
+using LifelogBb.Models.TrainingPlans;
+using LifelogBb.Utilities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace LifelogBb.Controllers
+{
+    public class TrainingPlansController : Controller
+    {
+        private readonly LifelogBbContext _context;
+        private readonly TrainingPlansService _service;
+        protected readonly IMapper _mapper;
+
+        private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+        public TrainingPlansController(LifelogBbContext context, TrainingPlansService service, IMapper mapper)
+        {
+            _context = context;
+            _service = service;
+            _mapper = mapper;
+        }
+
+        // GET: TrainingPlans
+        public async Task<IActionResult> Index()
+        {
+            var all = await _context.TrainingPlans.Include(p => p.Sets).ToListAsync();
+
+            var model = new TrainingPlanIndexViewModel
+            {
+                Templates = all.Where(p => p.Date == null && !p.IsArchived).OrderBy(p => p.Name).ToList(),
+                DayPlans = all.Where(p => p.Date != null && !p.IsArchived).OrderByDescending(p => p.Date).ToList(),
+                Archived = all.Where(p => p.IsArchived).OrderByDescending(p => p.UpdatedAt).ToList()
+            };
+
+            return View(model);
+        }
+
+        // GET: TrainingPlans/Table
+        public async Task<IActionResult> Table(string sortOrder, string currentFilter, string searchString, string? filter, int? pageNumber)
+        {
+            ViewData["CurrentSort"] = sortOrder;
+
+            if (searchString != null)
+            {
+                pageNumber = 1;
+            }
+            else
+            {
+                searchString = currentFilter;
+            }
+
+            ViewData["CurrentFilter"] = searchString;
+            ViewData["Filter"] = filter;
+
+            var plans = _context.TrainingPlans.Include(p => p.Sets).AsQueryable();
+            plans = plans.FilterByGroup(filter);
+            plans = plans.SortByName(sortOrder, $"{nameof(TrainingPlan.CreatedAt)}_desc");
+
+            var config = Config.GetConfig(_context);
+            var list = await PaginatedList<TrainingPlan>.CreateAsync(plans.AsNoTracking(), pageNumber ?? 1, config.TrainingPlanPageSize);
+            return View(new PaginatedListViewModel<TrainingPlan>(list, config));
+        }
+
+        // GET: TrainingPlans/Details/5
+        public async Task<IActionResult> Details(long? id)
+        {
+            if (id == null)
+                return NotFound();
+
+            var plan = await _context.TrainingPlans.Include(p => p.Sets).FirstOrDefaultAsync(p => p.Id == id);
+            if (plan == null)
+                return NotFound();
+
+            var model = await BuildComparisonAsync<TrainingPlanDetailsViewModel>(plan);
+            return View(model);
+        }
+
+        // GET: TrainingPlans/Create
+        public async Task<IActionResult> Create()
+        {
+            await PopulateExerciseListAsync();
+            return View(new EditTrainingPlanViewModel { SetsJson = "[]" });
+        }
+
+        // POST: TrainingPlans/Create
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Create([Bind("Name,Description,Date,IsArchived,SetsJson")] EditTrainingPlanViewModel model)
+        {
+            var rows = ParseSetsJson(model.SetsJson);
+            ValidateRows(rows);
+
+            if (ModelState.IsValid)
+            {
+                var plan = new TrainingPlan
+                {
+                    Name = model.Name,
+                    Description = model.Description,
+                    Date = model.Date,
+                    IsArchived = model.IsArchived
+                };
+                plan.SetCreateFields();
+                plan.Sets = BuildSets(rows, plan);
+
+                _context.Add(plan);
+                await _context.SaveChangesAsync();
+                return RedirectToAction(nameof(Index));
+            }
+
+            await PopulateExerciseListAsync();
+            return View(model);
+        }
+
+        // GET: TrainingPlans/Edit/5
+        public async Task<IActionResult> Edit(long? id)
+        {
+            if (id == null)
+                return NotFound();
+
+            var plan = await _context.TrainingPlans.Include(p => p.Sets).FirstOrDefaultAsync(p => p.Id == id);
+            if (plan == null)
+                return NotFound();
+
+            var model = _mapper.Map<EditTrainingPlanViewModel>(plan);
+            model.SetsJson = JsonSerializer.Serialize(plan.Sets.OrderBy(s => s.SortOrder)
+                .Select(s => new PlanSetRow { Exercise = s.Exercise, Reps = s.Reps, Weight = s.Weight, Notes = s.Notes }));
+
+            await PopulateExerciseListAsync();
+            return View(model);
+        }
+
+        // POST: TrainingPlans/Edit/5
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Edit(long id, [Bind("Id,Name,Description,Date,IsArchived,SetsJson")] EditTrainingPlanViewModel model)
+        {
+            if (id != model.Id)
+                return NotFound();
+
+            var rows = ParseSetsJson(model.SetsJson);
+            ValidateRows(rows);
+
+            var plan = await _context.TrainingPlans.Include(p => p.Sets).FirstOrDefaultAsync(p => p.Id == id);
+            if (plan == null)
+                return NotFound();
+
+            if (ModelState.IsValid)
+            {
+                plan.Name = model.Name;
+                plan.Description = model.Description;
+                plan.Date = model.Date;
+                plan.IsArchived = model.IsArchived;
+                plan.SetUpdateFields();
+
+                // Full replace. StrengthTraining rows linked to a removed set keep their history; only
+                // the link is cleared (SetNull FK behavior configured in LifelogBbContext).
+                _context.TrainingPlanSets.RemoveRange(plan.Sets);
+                plan.Sets = BuildSets(rows, plan);
+
+                await _context.SaveChangesAsync();
+                return RedirectToAction(nameof(Index));
+            }
+
+            await PopulateExerciseListAsync();
+            return View(model);
+        }
+
+        // GET: TrainingPlans/Copy/5
+        public async Task<IActionResult> Copy(long? id)
+        {
+            if (id == null)
+                return NotFound();
+
+            var plan = await _context.TrainingPlans.FirstOrDefaultAsync(p => p.Id == id);
+            if (plan == null)
+                return NotFound();
+
+            ViewData["SourceName"] = plan.Name;
+            return View(new CopyTrainingPlanViewModel { SourceId = plan.Id, Name = $"{plan.Name} (Copy)" });
+        }
+
+        // POST: TrainingPlans/Copy/5
+        [HttpPost, ActionName("Copy")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> CopyConfirmed(CopyTrainingPlanViewModel model)
+        {
+            var result = await _service.CopyPlan(model.SourceId, model.Date, model.Name);
+            if (result == null)
+                return NotFound();
+
+            return RedirectToAction(nameof(Edit), new { id = result.Id });
+        }
+
+        // GET: TrainingPlans/Delete/5
+        public async Task<IActionResult> Delete(long? id)
+        {
+            if (id == null)
+                return NotFound();
+
+            var plan = await _context.TrainingPlans.Include(p => p.Sets).FirstOrDefaultAsync(p => p.Id == id);
+            if (plan == null)
+                return NotFound();
+
+            return View(plan);
+        }
+
+        // POST: TrainingPlans/Delete/5
+        [HttpPost, ActionName("Delete")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteConfirmed(long id)
+        {
+            var plan = await _context.TrainingPlans.FindAsync(id);
+            if (plan != null)
+            {
+                _context.TrainingPlans.Remove(plan);
+                await _context.SaveChangesAsync();
+            }
+
+            return RedirectToAction(nameof(Index));
+        }
+
+        // GET: TrainingPlans/Workout/5
+        public async Task<IActionResult> Workout(long? id)
+        {
+            if (id == null)
+                return NotFound();
+
+            var plan = await _context.TrainingPlans.Include(p => p.Sets).FirstOrDefaultAsync(p => p.Id == id);
+            if (plan == null)
+                return NotFound();
+
+            // A template is reusable and has no single day of its own -- starting a workout from it
+            // creates a dated copy for today so the workout instance and its done-state are unambiguous.
+            if (plan.Date == null)
+            {
+                var copy = await _service.CopyPlan(plan.Id, DateTime.UtcNow.Date, plan.Name);
+                if (copy == null)
+                    return NotFound();
+
+                return RedirectToAction(nameof(Workout), new { id = copy.Id });
+            }
+
+            var model = await BuildComparisonAsync<WorkoutViewModel>(plan);
+            return View(model);
+        }
+
+        public class ConfirmSetRequest
+        {
+            public long PlanSetId { get; set; }
+            public int Reps { get; set; }
+            public double Weight { get; set; }
+            public int Rating { get; set; } = 3;
+            public string? Notes { get; set; }
+        }
+
+        // POST: TrainingPlans/WorkoutConfirmSet
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> WorkoutConfirmSet([FromBody] ConfirmSetRequest request)
+        {
+            var planSet = await _context.TrainingPlanSets.Include(s => s.TrainingPlan).FirstOrDefaultAsync(s => s.Id == request.PlanSetId);
+            if (planSet == null)
+                return NotFound();
+
+            var training = new StrengthTraining
+            {
+                Exercise = planSet.Exercise,
+                Reps = request.Reps,
+                Weight = request.Weight,
+                Rating = request.Rating,
+                Notes = request.Notes,
+                Date = planSet.TrainingPlan.Date ?? DateTime.UtcNow.Date,
+                TrainingPlanId = planSet.TrainingPlanId,
+                TrainingPlanSetId = planSet.Id
+            };
+            training.SetCreateFields();
+
+            _context.StrengthTrainings.Add(training);
+            await _context.SaveChangesAsync();
+
+            return Json(new { ok = true, trainingId = training.Id });
+        }
+
+        public class UndoSetRequest
+        {
+            public long TrainingId { get; set; }
+        }
+
+        // POST: TrainingPlans/WorkoutUndoSet
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> WorkoutUndoSet([FromBody] UndoSetRequest request)
+        {
+            var training = await _context.StrengthTrainings.FirstOrDefaultAsync(t => t.Id == request.TrainingId);
+            if (training == null || training.TrainingPlanSetId == null)
+                return NotFound();
+
+            _context.StrengthTrainings.Remove(training);
+            await _context.SaveChangesAsync();
+
+            return Json(new { ok = true });
+        }
+
+        private async Task<T> BuildComparisonAsync<T>(TrainingPlan plan) where T : new()
+        {
+            var trainings = await _context.StrengthTrainings
+                .Where(t => t.TrainingPlanId == plan.Id)
+                .ToListAsync();
+
+            var byPlanSet = trainings
+                .Where(t => t.TrainingPlanSetId != null)
+                .GroupBy(t => t.TrainingPlanSetId!.Value)
+                .ToDictionary(g => g.Key, g => g.OrderBy(t => t.CreatedAt).First());
+
+            var rows = plan.Sets.OrderBy(s => s.SortOrder)
+                .Select(s => new PlanSetComparisonRow
+                {
+                    Planned = s,
+                    Actual = byPlanSet.TryGetValue(s.Id, out var actual) ? actual : null
+                })
+                .ToList();
+
+            var extras = trainings.Where(t => t.TrainingPlanSetId == null).OrderBy(t => t.CreatedAt).ToList();
+
+            object model = typeof(T) == typeof(WorkoutViewModel)
+                ? new WorkoutViewModel { Plan = plan, Rows = rows, ExtraTrainings = extras }
+                : new TrainingPlanDetailsViewModel { Plan = plan, Rows = rows, ExtraTrainings = extras };
+
+            return (T)model;
+        }
+
+        private static List<PlanSetRow> ParseSetsJson(string? setsJson)
+        {
+            if (string.IsNullOrWhiteSpace(setsJson))
+                return new List<PlanSetRow>();
+
+            try
+            {
+                return JsonSerializer.Deserialize<List<PlanSetRow>>(setsJson, JsonOptions) ?? new List<PlanSetRow>();
+            }
+            catch (JsonException)
+            {
+                return new List<PlanSetRow>();
+            }
+        }
+
+        private void ValidateRows(List<PlanSetRow> rows)
+        {
+            if (rows.Count == 0)
+            {
+                ModelState.AddModelError(string.Empty, "Add at least one set.");
+                return;
+            }
+
+            for (var i = 0; i < rows.Count; i++)
+            {
+                if (string.IsNullOrWhiteSpace(rows[i].Exercise))
+                    ModelState.AddModelError(string.Empty, $"Set {i + 1}: exercise is required.");
+                if (rows[i].Reps < 0)
+                    ModelState.AddModelError(string.Empty, $"Set {i + 1}: reps cannot be negative.");
+                if (rows[i].Weight < 0)
+                    ModelState.AddModelError(string.Empty, $"Set {i + 1}: weight cannot be negative.");
+            }
+        }
+
+        private static List<TrainingPlanSet> BuildSets(List<PlanSetRow> rows, TrainingPlan plan)
+        {
+            var sets = new List<TrainingPlanSet>();
+            for (var i = 0; i < rows.Count; i++)
+            {
+                var set = new TrainingPlanSet
+                {
+                    Exercise = rows[i].Exercise,
+                    SortOrder = i,
+                    Reps = rows[i].Reps,
+                    Weight = rows[i].Weight,
+                    Notes = rows[i].Notes,
+                    TrainingPlan = plan
+                };
+                set.SetCreateFields();
+                sets.Add(set);
+            }
+            return sets;
+        }
+
+        private async Task PopulateExerciseListAsync()
+        {
+            var exercises = await _context.StrengthTrainings.Select(s => s.Exercise).Distinct().ToListAsync();
+            ViewData["ExerciseList"] = string.Join(",", exercises);
+        }
+    }
+
+    public class CopyTrainingPlanViewModel
+    {
+        public long SourceId { get; set; }
+        public string Name { get; set; } = string.Empty;
+        [System.ComponentModel.DataAnnotations.DataType(System.ComponentModel.DataAnnotations.DataType.Date)]
+        public DateTime? Date { get; set; }
+    }
+}

--- a/LifelogBb/Controllers/TrainingPlansController.cs
+++ b/LifelogBb/Controllers/TrainingPlansController.cs
@@ -18,6 +18,10 @@ namespace LifelogBb.Controllers
 
         private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
+        // plansetseditor.js reads plain lowercase field names (exercise/reps/weight/notes) from the
+        // hidden SetsJson input it seeds itself with, so server-rendered JSON must match that casing.
+        private static readonly JsonSerializerOptions CamelCaseJsonOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
         public TrainingPlansController(LifelogBbContext context, TrainingPlansService service, IMapper mapper)
         {
             _context = context;
@@ -128,7 +132,8 @@ namespace LifelogBb.Controllers
 
             var model = _mapper.Map<EditTrainingPlanViewModel>(plan);
             model.SetsJson = JsonSerializer.Serialize(plan.Sets.OrderBy(s => s.SortOrder)
-                .Select(s => new PlanSetRow { Exercise = s.Exercise, Reps = s.Reps, Weight = s.Weight, Notes = s.Notes }));
+                .Select(s => new PlanSetRow { Exercise = s.Exercise, Reps = s.Reps, Weight = s.Weight, Notes = s.Notes }),
+                CamelCaseJsonOptions);
 
             await PopulateExerciseListAsync();
             return View(model);

--- a/LifelogBb/McpControllers/TrainingPlansTool.cs
+++ b/LifelogBb/McpControllers/TrainingPlansTool.cs
@@ -1,0 +1,53 @@
+using LifelogBb.ApiDTOs;
+using LifelogBb.ApiDTOs.TrainingPlans;
+using LifelogBb.ApiServices;
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+
+namespace LifelogBb.McpControllers
+{
+    [McpServerToolType]
+    public class TrainingPlansTool : BaseTool<TrainingPlansService, TrainingPlanInput, TrainingPlanOutput>
+    {
+        public TrainingPlansTool(TrainingPlansService service) : base(service)
+        {
+        }
+
+        [McpServerTool(Name = "GetAllTrainingPlans", Title = "Get All Training Plans", ReadOnly = true, OpenWorld = false), Description("Get strength training plans, newest first, including their planned sets in order. A plan with no Date is a reusable base/template plan; a plan with a Date is a concrete plan for that specific day. Optionally filter (e.g. {\"IsArchived\":false}), sort, and limit results.")]
+        public async Task<IEnumerable<TrainingPlanOutput>> McpGetAll(
+            [Description("Optional JSON filter expression")] string? filter = null,
+            [Description("Optional sort field, for example \"CreatedAt\" ascending or \"CreatedAt_desc\" descending. Defaults to newest first.")] string? sort = null,
+            [Description("Optional maximum number of entries to return.")] int? limit = null)
+        {
+            return await GetAllFiltered(filter, sort, limit);
+        }
+
+        [McpServerTool(Name = "CreateTrainingPlan", Title = "Create training plan", Destructive = false, OpenWorld = false), Description("Create a new strength training plan with its planned sets in one call. The order of the Sets array becomes the order the sets are performed in. Leave Date empty for a base/template plan, or set it to create a concrete day plan.")]
+        public async Task<TrainingPlanOutput?> Create(TrainingPlanInput model)
+        {
+            return await _service.Create(model);
+        }
+
+        [McpServerTool(Name = "UpdateTrainingPlan", Title = "Update training plan", Destructive = true, Idempotent = true, OpenWorld = false), Description("Update an existing training plan. All fields are replaced by the provided values, including the full list of Sets: sets not included are removed. Logged strength trainings that reference a removed set keep their history but lose that link. Prefer editing templates and using CopyTrainingPlan for individual days rather than rewriting a day plan that already has logged trainings.")]
+        public async Task<TrainingPlanOutput?> Update([Description("Id of the training plan to update")] long id, TrainingPlanInput model)
+        {
+            return await _service.Update(id, model);
+        }
+
+        [McpServerTool(Name = "DeleteTrainingPlan", Title = "Delete training plan", Destructive = true, Idempotent = true, OpenWorld = false), Description("Delete a training plan and its planned sets. Strength trainings already logged against it are kept, only the link to the plan is cleared.")]
+        public async Task<DeleteOutput?> Delete([Description("Id of the training plan to delete")] long id)
+        {
+            var deletedId = await _service.Delete(id);
+            return deletedId == null ? null : new DeleteOutput() { Id = deletedId.Value };
+        }
+
+        [McpServerTool(Name = "CopyTrainingPlan", Title = "Copy training plan", Destructive = false, OpenWorld = false), Description("Duplicate an existing training plan together with all its planned sets. Useful for creating a new version of a base plan, or for deriving a concrete day plan (pass a date) from a template or from a previous day's plan.")]
+        public async Task<TrainingPlanOutput?> Copy(
+            [Description("Id of the plan to copy")] long sourceId,
+            [Description("Optional date (yyyy-MM-dd) to make the copy a concrete day plan instead of another template")] DateTime? date = null,
+            [Description("Optional name for the copy. Defaults to \"<source name> (Copy)\"")] string? name = null)
+        {
+            return await _service.CopyPlan(sourceId, date, name);
+        }
+    }
+}

--- a/LifelogBb/Migrations/20260809090921_TrainingPlans.Designer.cs
+++ b/LifelogBb/Migrations/20260809090921_TrainingPlans.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LifelogBb.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LifelogBb.Migrations
 {
     [DbContext(typeof(LifelogBbContext))]
-    partial class LifelogBbContextModelSnapshot : ModelSnapshot
+    [Migration("20260809090921_TrainingPlans")]
+    partial class TrainingPlans
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/LifelogBb/Migrations/20260809090921_TrainingPlans.cs
+++ b/LifelogBb/Migrations/20260809090921_TrainingPlans.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LifelogBb.Migrations
+{
+    /// <inheritdoc />
+    public partial class TrainingPlans : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Date",
+                table: "StrengthTrainings",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.Sql("UPDATE StrengthTrainings SET Date = CreatedAt");
+
+            migrationBuilder.AddColumn<long>(
+                name: "TrainingPlanId",
+                table: "StrengthTrainings",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "TrainingPlanSetId",
+                table: "StrengthTrainings",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "TrainingPlanPageSize",
+                table: "Configs",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 20);
+
+            migrationBuilder.CreateTable(
+                name: "TrainingPlans",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Name = table.Column<string>(type: "TEXT", nullable: false),
+                    Description = table.Column<string>(type: "TEXT", nullable: true),
+                    Date = table.Column<DateTime>(type: "TEXT", nullable: true),
+                    IsArchived = table.Column<bool>(type: "INTEGER", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TrainingPlans", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TrainingPlanSets",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    TrainingPlanId = table.Column<long>(type: "INTEGER", nullable: false),
+                    Exercise = table.Column<string>(type: "TEXT", nullable: false),
+                    SortOrder = table.Column<int>(type: "INTEGER", nullable: false),
+                    Reps = table.Column<int>(type: "INTEGER", nullable: false),
+                    Weight = table.Column<double>(type: "REAL", nullable: false),
+                    Notes = table.Column<string>(type: "TEXT", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TrainingPlanSets", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TrainingPlanSets_TrainingPlans_TrainingPlanId",
+                        column: x => x.TrainingPlanId,
+                        principalTable: "TrainingPlans",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StrengthTrainings_TrainingPlanId",
+                table: "StrengthTrainings",
+                column: "TrainingPlanId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StrengthTrainings_TrainingPlanSetId",
+                table: "StrengthTrainings",
+                column: "TrainingPlanSetId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TrainingPlanSets_TrainingPlanId",
+                table: "TrainingPlanSets",
+                column: "TrainingPlanId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_StrengthTrainings_TrainingPlanSets_TrainingPlanSetId",
+                table: "StrengthTrainings",
+                column: "TrainingPlanSetId",
+                principalTable: "TrainingPlanSets",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_StrengthTrainings_TrainingPlans_TrainingPlanId",
+                table: "StrengthTrainings",
+                column: "TrainingPlanId",
+                principalTable: "TrainingPlans",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_StrengthTrainings_TrainingPlanSets_TrainingPlanSetId",
+                table: "StrengthTrainings");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_StrengthTrainings_TrainingPlans_TrainingPlanId",
+                table: "StrengthTrainings");
+
+            migrationBuilder.DropTable(
+                name: "TrainingPlanSets");
+
+            migrationBuilder.DropTable(
+                name: "TrainingPlans");
+
+            migrationBuilder.DropIndex(
+                name: "IX_StrengthTrainings_TrainingPlanId",
+                table: "StrengthTrainings");
+
+            migrationBuilder.DropIndex(
+                name: "IX_StrengthTrainings_TrainingPlanSetId",
+                table: "StrengthTrainings");
+
+            migrationBuilder.DropColumn(
+                name: "Date",
+                table: "StrengthTrainings");
+
+            migrationBuilder.DropColumn(
+                name: "TrainingPlanId",
+                table: "StrengthTrainings");
+
+            migrationBuilder.DropColumn(
+                name: "TrainingPlanSetId",
+                table: "StrengthTrainings");
+
+            migrationBuilder.DropColumn(
+                name: "TrainingPlanPageSize",
+                table: "Configs");
+        }
+    }
+}

--- a/LifelogBb/Models/AutoMapperProfile.cs
+++ b/LifelogBb/Models/AutoMapperProfile.cs
@@ -10,6 +10,7 @@ using LifelogBb.Models.Habits;
 using LifelogBb.Models.Todos;
 using LifelogBb.Models.Quotes;
 using LifelogBb.Models.Goals;
+using LifelogBb.Models.TrainingPlans;
 
 namespace LifelogBb.Models
 {
@@ -62,6 +63,12 @@ namespace LifelogBb.Models
             // Goals
             CreateMap<EditGoalViewModel, Goal>();
             CreateMap<Goal, EditGoalViewModel>();
+
+            // TrainingPlans - Sets/SetsJson are handled explicitly by TrainingPlansController, not AutoMapper.
+            CreateMap<EditTrainingPlanViewModel, TrainingPlan>()
+                .ForMember(dest => dest.Sets, opt => opt.Ignore());
+            CreateMap<TrainingPlan, EditTrainingPlanViewModel>()
+                .ForMember(dest => dest.SetsJson, opt => opt.Ignore());
         }
     }
 }

--- a/LifelogBb/Models/Entities/Config.cs
+++ b/LifelogBb/Models/Entities/Config.cs
@@ -30,6 +30,8 @@ namespace LifelogBb.Models.Entities
 
         public int StrengthTrainingPageSize { get; set; } = 20;
 
+        public int TrainingPlanPageSize { get; set; } = 20;
+
         public int EnduranceTrainingPageSize { get; set; } = 20;
 
         public int TodoPageSize { get; set; } = 20;

--- a/LifelogBb/Models/Entities/StrengthTraining.cs
+++ b/LifelogBb/Models/Entities/StrengthTraining.cs
@@ -22,6 +22,22 @@ namespace LifelogBb.Models.Entities
         [DefaultValue(3)]
         public int Rating { get; set; }
 
+        // The day this set was trained. Distinct from CreatedAt so sets can be logged retroactively
+        // and day plans can be matched to the day they are for.
+        [DataType(DataType.Date)]
+        public DateTime Date { get; set; }
+
+        // Set when this entry was logged against a training plan (template or day plan).
+        public long? TrainingPlanId { get; set; }
+
+        // Set when this entry was logged against a specific planned set, enabling planned-vs-actual comparison
+        // and letting the workout capture view resume/derive its done state from the database.
+        public long? TrainingPlanSetId { get; set; }
+
+        public TrainingPlan? TrainingPlan { get; set; }
+
+        public TrainingPlanSet? TrainingPlanSet { get; set; }
+
         public StrengthTraining()
         {
             // Default constructor

--- a/LifelogBb/Models/Entities/TrainingPlan.cs
+++ b/LifelogBb/Models/Entities/TrainingPlan.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LifelogBb.Models.Entities
+{
+    public class TrainingPlan : BaseEntity
+    {
+        [Required]
+        [MinLength(1)]
+        public string Name { get; set; } = string.Empty;
+
+        public string? Description { get; set; }
+
+        // Null = base/template plan, reusable as a starting point.
+        // Set = a concrete day plan, meant to be worked through once.
+        [DataType(DataType.Date)]
+        public DateTime? Date { get; set; }
+
+        public bool IsArchived { get; set; }
+
+        public ICollection<TrainingPlanSet> Sets { get; set; } = new List<TrainingPlanSet>();
+    }
+}

--- a/LifelogBb/Models/Entities/TrainingPlanSet.cs
+++ b/LifelogBb/Models/Entities/TrainingPlanSet.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace LifelogBb.Models.Entities
+{
+    public class TrainingPlanSet : BaseEntity
+    {
+        [Required]
+        public long TrainingPlanId { get; set; }
+
+        [Required]
+        [MinLength(1)]
+        public string Exercise { get; set; } = string.Empty;
+
+        // Position of this set within the plan. Assigned from array order on Create/Update, not user-editable.
+        public int SortOrder { get; set; }
+
+        public int Reps { get; set; }
+
+        [DisplayFormat(DataFormatString = "{0:0.00}")]
+        public double Weight { get; set; }
+
+        public string? Notes { get; set; }
+
+        public TrainingPlan TrainingPlan { get; set; } = null!;
+    }
+}

--- a/LifelogBb/Models/Home/EditConfigViewModel.cs
+++ b/LifelogBb/Models/Home/EditConfigViewModel.cs
@@ -39,6 +39,8 @@ namespace LifelogBb.Models.Home
 
         public int StrengthTrainingPageSize { get; set; }
 
+        public int TrainingPlanPageSize { get; set; }
+
         public int EnduranceTrainingPageSize { get; set; }
 
         public int TodoPageSize { get; set; }

--- a/LifelogBb/Models/LifelogBbContext.cs
+++ b/LifelogBb/Models/LifelogBbContext.cs
@@ -20,6 +20,8 @@ namespace LifelogBb.Models
         public DbSet<Config> Configs { get; set; } = null!;
         public DbSet<ChatSession> ChatSessions { get; set; } = null!;
         public DbSet<ChatSessionMessage> ChatSessionMessages { get; set; } = null!;
+        public DbSet<TrainingPlan> TrainingPlans { get; set; } = null!;
+        public DbSet<TrainingPlanSet> TrainingPlanSets { get; set; } = null!;
 
         private readonly IConfiguration _configuration;
 
@@ -66,6 +68,7 @@ namespace LifelogBb.Models
             modelBuilder.Entity<Config>().Property(b => b.JournalPageSize).HasDefaultValue(20);
             modelBuilder.Entity<Config>().Property(b => b.QuotePageSize).HasDefaultValue(20);
             modelBuilder.Entity<Config>().Property(b => b.StrengthTrainingPageSize).HasDefaultValue(20);
+            modelBuilder.Entity<Config>().Property(b => b.TrainingPlanPageSize).HasDefaultValue(20);
             modelBuilder.Entity<Config>().Property(b => b.TodoPageSize).HasDefaultValue(20);
             modelBuilder.Entity<Config>().Property(b => b.WeightPageSize).HasDefaultValue(20);
             modelBuilder.Entity<Config>().Property(b => b.FeedToken).HasDefaultValue("ChangeMeInTheConfig");
@@ -87,6 +90,26 @@ namespace LifelogBb.Models
                 .OnDelete(DeleteBehavior.Cascade);
 
             modelBuilder.Entity<Journal>().HasIndex(j => j.Date).IsUnique();
+
+            modelBuilder.Entity<TrainingPlan>()
+                .HasMany(p => p.Sets)
+                .WithOne(s => s.TrainingPlan)
+                .HasForeignKey(s => s.TrainingPlanId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // Deleting a plan or a plan set must not delete the logged StrengthTraining rows that
+            // reference it -- the actual data a user recorded must survive plan cleanup.
+            modelBuilder.Entity<StrengthTraining>()
+                .HasOne(t => t.TrainingPlan)
+                .WithMany()
+                .HasForeignKey(t => t.TrainingPlanId)
+                .OnDelete(DeleteBehavior.SetNull);
+
+            modelBuilder.Entity<StrengthTraining>()
+                .HasOne(t => t.TrainingPlanSet)
+                .WithMany()
+                .HasForeignKey(t => t.TrainingPlanSetId)
+                .OnDelete(DeleteBehavior.SetNull);
         }
 
         public void BeginTransaction()

--- a/LifelogBb/Models/StrengthTrainings/EditStrengthTrainingViewModel.cs
+++ b/LifelogBb/Models/StrengthTrainings/EditStrengthTrainingViewModel.cs
@@ -17,5 +17,12 @@ namespace LifelogBb.Models.StrengthTrainings
 
         [Range(1, 5)]
         public int Rating { get; set; }
+
+        [DataType(DataType.Date)]
+        public DateTime Date { get; set; }
+
+        public long? TrainingPlanId { get; set; }
+
+        public long? TrainingPlanSetId { get; set; }
     }
 }

--- a/LifelogBb/Models/StrengthTrainings/StrengthTrainingGraphViewModel.cs
+++ b/LifelogBb/Models/StrengthTrainings/StrengthTrainingGraphViewModel.cs
@@ -1,0 +1,8 @@
+namespace LifelogBb.Models.StrengthTrainings
+{
+    public class StrengthTrainingGraphViewModel
+    {
+        public List<string> Exercises { get; set; } = new();
+        public string? SelectedExercise { get; set; }
+    }
+}

--- a/LifelogBb/Models/StrengthTrainings/StrengthTrainingSession.cs
+++ b/LifelogBb/Models/StrengthTrainings/StrengthTrainingSession.cs
@@ -1,0 +1,16 @@
+namespace LifelogBb.Models.StrengthTrainings
+{
+    // One row of the Sessions overview: all sets trained on a single day, grouped together.
+    public class StrengthTrainingSession
+    {
+        public DateTime Date { get; set; }
+        public int SetCount { get; set; }
+        public double Volume { get; set; }
+        public List<string> Exercises { get; set; } = new();
+        public long? TrainingPlanId { get; set; }
+        public string? TrainingPlanName { get; set; }
+        public int? PlannedSetCount { get; set; }
+
+        public double? CompletionRate => PlannedSetCount is > 0 ? Math.Min(1.0, (double)SetCount / PlannedSetCount.Value) : null;
+    }
+}

--- a/LifelogBb/Models/TrainingPlans/EditTrainingPlanViewModel.cs
+++ b/LifelogBb/Models/TrainingPlans/EditTrainingPlanViewModel.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LifelogBb.Models.TrainingPlans
+{
+    // One row as edited in the plan set editor (wwwroot/js/plansetseditor.js), serialized to/from the
+    // hidden SetsJson field below. SortOrder is not part of it -- array order is the order.
+    public class PlanSetRow
+    {
+        public string Exercise { get; set; } = string.Empty;
+        public int Reps { get; set; }
+        public double Weight { get; set; }
+        public string? Notes { get; set; }
+    }
+
+    public class EditTrainingPlanViewModel
+    {
+        public long Id { get; set; }
+
+        [Required]
+        [MinLength(1)]
+        public string Name { get; set; } = string.Empty;
+
+        public string? Description { get; set; }
+
+        [DataType(DataType.Date)]
+        public DateTime? Date { get; set; }
+
+        public bool IsArchived { get; set; }
+
+        // Serialized List<PlanSetRow> JSON, populated/consumed by plansetseditor.js.
+        public string SetsJson { get; set; } = "[]";
+    }
+}

--- a/LifelogBb/Models/TrainingPlans/PlanSectionModel.cs
+++ b/LifelogBb/Models/TrainingPlans/PlanSectionModel.cs
@@ -1,0 +1,21 @@
+using LifelogBb.Models.Entities;
+
+namespace LifelogBb.Models.TrainingPlans
+{
+    // View model for the Views/TrainingPlans/_PlanSection.cshtml partial used by Index.cshtml.
+    public class PlanSectionModel
+    {
+        public string? Title { get; }
+        public string? Subtitle { get; }
+        public List<TrainingPlan> Plans { get; }
+        public bool ShowStart { get; }
+
+        public PlanSectionModel(string? title, string? subtitle, List<TrainingPlan> plans, bool showStart)
+        {
+            Title = title;
+            Subtitle = subtitle;
+            Plans = plans;
+            ShowStart = showStart;
+        }
+    }
+}

--- a/LifelogBb/Models/TrainingPlans/PlanSetComparisonRow.cs
+++ b/LifelogBb/Models/TrainingPlans/PlanSetComparisonRow.cs
@@ -1,0 +1,33 @@
+using LifelogBb.Models.Entities;
+
+namespace LifelogBb.Models.TrainingPlans
+{
+    // Pairs a planned set with the StrengthTraining row (if any) that fulfilled it. Used by both the
+    // Workout capture view (Actual == null means "not done yet") and the read-only Details/Soll-Ist view.
+    public class PlanSetComparisonRow
+    {
+        public TrainingPlanSet Planned { get; set; } = null!;
+        public StrengthTraining? Actual { get; set; }
+    }
+
+    public class TrainingPlanDetailsViewModel
+    {
+        public TrainingPlan Plan { get; set; } = null!;
+        public List<PlanSetComparisonRow> Rows { get; set; } = new();
+        public List<StrengthTraining> ExtraTrainings { get; set; } = new();
+
+        public int DoneCount => Rows.Count(r => r.Actual != null);
+        public int TotalCount => Rows.Count;
+        public double CompletionRate => TotalCount == 0 ? 0 : (double)DoneCount / TotalCount;
+    }
+
+    public class WorkoutViewModel
+    {
+        public TrainingPlan Plan { get; set; } = null!;
+        public List<PlanSetComparisonRow> Rows { get; set; } = new();
+        public List<StrengthTraining> ExtraTrainings { get; set; } = new();
+
+        public int DoneCount => Rows.Count(r => r.Actual != null);
+        public int TotalCount => Rows.Count;
+    }
+}

--- a/LifelogBb/Models/TrainingPlans/TrainingPlanIndexViewModel.cs
+++ b/LifelogBb/Models/TrainingPlans/TrainingPlanIndexViewModel.cs
@@ -1,0 +1,11 @@
+using LifelogBb.Models.Entities;
+
+namespace LifelogBb.Models.TrainingPlans
+{
+    public class TrainingPlanIndexViewModel
+    {
+        public List<TrainingPlan> Templates { get; set; } = new();
+        public List<TrainingPlan> DayPlans { get; set; } = new();
+        public List<TrainingPlan> Archived { get; set; } = new();
+    }
+}

--- a/LifelogBb/Program.cs
+++ b/LifelogBb/Program.cs
@@ -78,6 +78,7 @@ namespace LifelogBb
             services.AddScoped<WeightsService>();
             services.AddScoped<JournalsService>();
             services.AddScoped<StrengthTrainingsService>();
+            services.AddScoped<TrainingPlansService>();
             services.AddScoped<EnduranceTrainingsService>();
             services.AddScoped<QuotesService>();
             services.AddScoped<TodosService>();

--- a/LifelogBb/Utilities/EntityType.cs
+++ b/LifelogBb/Utilities/EntityType.cs
@@ -11,6 +11,7 @@
         Quote = 6,
         Todo = 7,
         Goal = 8,
-        Habit = 9
+        Habit = 9,
+        TrainingPlan = 10
     }
 }

--- a/LifelogBb/Views/Home/Config.cshtml
+++ b/LifelogBb/Views/Home/Config.cshtml
@@ -94,6 +94,11 @@
                             <span asp-validation-for="EnduranceTrainingPageSize" class="text-danger"></span>
                         </div>
                         <div class="form-group mb-3">
+                            <label asp-for="TrainingPlanPageSize" class="control-label mb-1"></label>
+                            <input asp-for="TrainingPlanPageSize" class="form-control form-control-lg" />
+                            <span asp-validation-for="TrainingPlanPageSize" class="text-danger"></span>
+                        </div>
+                        <div class="form-group mb-3">
                             <label asp-for="TodoPageSize" class="control-label mb-1"></label>
                             <input asp-for="TodoPageSize" class="form-control form-control-lg" />
                             <span asp-validation-for="TodoPageSize" class="text-danger"></span>

--- a/LifelogBb/Views/Shared/Components/Navigation/Default.cshtml
+++ b/LifelogBb/Views/Shared/Components/Navigation/Default.cshtml
@@ -1,6 +1,11 @@
 ﻿@using LifelogBb.Views.Shared.Components.Navigation
 @model List<NavItem>
 
+@{
+    var currentController = ViewContext.RouteData.Values["controller"]?.ToString();
+    var currentAction = ViewContext.RouteData.Values["action"]?.ToString();
+}
+
 <ul class="navbar-nav pt-lg-3">
     @if (User.Identity is not null && User.Identity.IsAuthenticated)
     {
@@ -8,10 +13,21 @@
         {
             if (item.SubItems is not null && item.SubItems.Count > 0)
             {
-                var hasActiveSubItem = item.SubItems.Any(x => x.Controller == ViewContext.RouteData.Values["controller"]?.ToString() && x.Action == ViewContext.RouteData.Values["action"]?.ToString());
+                // A feature area often spans more actions (Create/Edit/Details/...) or even more than one
+                // controller (e.g. TrainingPlans alongside StrengthTrainings) than are listed as sub items.
+                // The group counts as active for any of those controllers, not just an exact action match,
+                // so it stays open while browsing pages that have no dedicated nav entry.
+                var controllersInGroup = item.SubItems.Select(x => x.Controller).ToHashSet();
+                var hasActiveSubItem = controllersInGroup.Contains(currentController);
                 var activeClass = hasActiveSubItem ? "active" : "";
                 var showSubItems = hasActiveSubItem ? "true" : "false";
                 var showSubItemsClass = hasActiveSubItem ? "show" : "";
+
+                // Within the group, highlight the sub item whose action matches exactly; if none does
+                // (e.g. a Create/Edit/Details page), fall back to the first sub item for that controller.
+                var exactMatch = item.SubItems.FirstOrDefault(x => x.Controller == currentController && x.Action == currentAction);
+                var fallbackMatch = exactMatch == null ? item.SubItems.FirstOrDefault(x => x.Controller == currentController) : null;
+
                 <li class="nav-item @activeClass">
                     <a class="nav-link dropdown-toggle @showSubItemsClass" href="#navbar-base" data-bs-toggle="dropdown" data-bs-auto-close="false" role="button" aria-expanded="@showSubItems">
                         <span class="nav-link-icon d-md-none d-lg-inline-block"><i class="@item.Icon"></i></span>
@@ -22,7 +38,7 @@
                             <div class="dropdown-menu-column">
                                 @foreach(var subItem in item.SubItems)
                                 {
-                                    var isSubActive = subItem.Controller == ViewContext.RouteData.Values["controller"]?.ToString() && subItem.Action == ViewContext.RouteData.Values["action"]?.ToString();
+                                    var isSubActive = subItem == exactMatch || subItem == fallbackMatch;
                                     var subActiveClass = isSubActive ? "active" : "";
                                     <a class="dropdown-item @subActiveClass" asp-area="" asp-controller="@subItem.Controller" asp-action="@subItem.Action">
                                         <span class="nav-link-icon d-md-none d-lg-inline-block"><i class="@subItem.Icon"></i></span>

--- a/LifelogBb/Views/Shared/Components/Navigation/Navigation.cs
+++ b/LifelogBb/Views/Shared/Components/Navigation/Navigation.cs
@@ -33,6 +33,8 @@ namespace LifelogBb.Views.Shared.Components.Navigation
                 new NavItem("Strength training", "fas fa-dumbbell", new List<NavItem>
                 {
                     new NavItem("StrengthTrainings", "Index", "Strength training", "fas fa-dumbbell"),
+                    new NavItem("TrainingPlans", "Index", "Plans", "fas fa-clipboard-list"),
+                    new NavItem("StrengthTrainings", "Sessions", "Sessions", "fas fa-calendar-week"),
                     new NavItem("StrengthTrainings", "Graph", "Graph", "fas fa-chart-line"),
                     new NavItem("StrengthTrainings", "Table", "Table", "fas fa-table"),
                 }),

--- a/LifelogBb/Views/Shared/EditorTemplates/PlanSets.cshtml
+++ b/LifelogBb/Views/Shared/EditorTemplates/PlanSets.cshtml
@@ -1,0 +1,60 @@
+@model string?
+@*
+    Plan set editor. The visible rows carry no name attribute and never post; the hidden input below
+    holds the serialized JSON array ("[{\"exercise\":...}]") that the model binder picks up as SetsJson.
+    See wwwroot/js/plansetseditor.js.
+*@
+<div class="plan-set-editor" data-plan-set-editor data-exercise-whitelist="@ViewData["ExerciseList"]">
+    <label class="control-label mb-1">Sets</label>
+    <input name="SetsJson" id="SetsJson" value="@Model" hidden />
+
+    <datalist id="planSetExerciseList">
+        @if (!string.IsNullOrEmpty(ViewData["ExerciseList"] as string))
+        {
+            foreach (var exercise in ((string)ViewData["ExerciseList"]!).Split(','))
+            {
+                <option value="@exercise"></option>
+            }
+        }
+    </datalist>
+
+    <div data-plan-set-rows></div>
+    <div data-plan-set-empty class="text-secondary mb-2">No sets yet. Add the first one below.</div>
+
+    <div>
+        <button type="button" class="btn btn-primary" data-plan-set-add><i class="fas fa-plus icon"></i> Add set</button>
+    </div>
+
+    <template data-plan-set-template>
+        <div class="card mb-2" data-plan-set-row>
+            <div class="card-body py-2">
+                <div class="row g-2 align-items-end">
+                    <div class="col-12 col-md-4">
+                        <label class="form-label small mb-1">Exercise</label>
+                        <input type="text" class="form-control form-control-lg" data-plan-set-exercise list="planSetExerciseList" />
+                    </div>
+                    <div class="col-4 col-md-2">
+                        <label class="form-label small mb-1">Reps</label>
+                        <input type="number" min="0" class="form-control form-control-lg" data-plan-set-reps value="10" />
+                    </div>
+                    <div class="col-4 col-md-2">
+                        <label class="form-label small mb-1">Weight</label>
+                        <input type="number" min="0" step="0.5" class="form-control form-control-lg" data-plan-set-weight value="0" />
+                    </div>
+                    <div class="col-4 col-md-2">
+                        <label class="form-label small mb-1">Notes</label>
+                        <input type="text" class="form-control form-control-lg" data-plan-set-notes />
+                    </div>
+                    <div class="col-12 col-md-2 text-end">
+                        <div class="btn-list flex-nowrap">
+                            <button type="button" class="btn btn-lg btn-outline-secondary" data-plan-set-up title="Move up"><i class="fas fa-arrow-up icon m-0"></i></button>
+                            <button type="button" class="btn btn-lg btn-outline-secondary" data-plan-set-down title="Move down"><i class="fas fa-arrow-down icon m-0"></i></button>
+                            <button type="button" class="btn btn-lg btn-outline-secondary" data-plan-set-duplicate title="Duplicate"><i class="fas fa-copy icon m-0"></i></button>
+                            <button type="button" class="btn btn-lg btn-outline-danger" data-plan-set-remove title="Remove"><i class="fas fa-trash icon m-0"></i></button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </template>
+</div>

--- a/LifelogBb/Views/StrengthTrainings/Create.cshtml
+++ b/LifelogBb/Views/StrengthTrainings/Create.cshtml
@@ -12,6 +12,11 @@
                 <div class="card-body">
                     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
                     <div class="form-group mb-3">
+                        <label asp-for="Date" class="control-label mb-1"></label>
+                        <input asp-for="Date" type="date" class="form-control form-control-lg" />
+                        <span asp-validation-for="Date" class="text-danger"></span>
+                    </div>
+                    <div class="form-group mb-3">
                         <label asp-for="Exercise" class="control-label mb-1"></label>
                         <input asp-for="Exercise" class="form-control form-control-lg" data-whitelist="@ViewData["ExerciseList"]" />
                         <span asp-validation-for="Exercise" class="text-danger"></span>

--- a/LifelogBb/Views/StrengthTrainings/Details.cshtml
+++ b/LifelogBb/Views/StrengthTrainings/Details.cshtml
@@ -14,6 +14,19 @@
                 <div class="card-body">
                     <dl class="row">
                         <dt class="col-sm-2">
+                            @Html.DisplayNameFor(model => model.Date)
+                        </dt>
+                        <dd class="col-sm-10">
+                            @Model?.Date.ToString("yyyy-MM-dd")
+                        </dd>
+                        @if (Model?.TrainingPlanId != null)
+                        {
+                            <dt class="col-sm-2">Plan</dt>
+                            <dd class="col-sm-10">
+                                <a asp-controller="TrainingPlans" asp-action="Details" asp-route-id="@Model.TrainingPlanId">View plan</a>
+                            </dd>
+                        }
+                        <dt class="col-sm-2">
                             @Html.DisplayNameFor(model => model.Exercise)
                         </dt>
                         <dd class="col-sm-10">

--- a/LifelogBb/Views/StrengthTrainings/Edit.cshtml
+++ b/LifelogBb/Views/StrengthTrainings/Edit.cshtml
@@ -12,6 +12,11 @@
                 <div class="card-body">
                     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
                     <div class="form-group mb-3">
+                        <label asp-for="Date" class="control-label mb-1"></label>
+                        <input asp-for="Date" type="date" class="form-control form-control-lg" />
+                        <span asp-validation-for="Date" class="text-danger"></span>
+                    </div>
+                    <div class="form-group mb-3">
                         <label asp-for="Exercise" class="control-label mb-1"></label>
                         <input asp-for="Exercise" class="form-control form-control-lg" />
                         <span asp-validation-for="Exercise" class="text-danger"></span>

--- a/LifelogBb/Views/StrengthTrainings/Graph.cshtml
+++ b/LifelogBb/Views/StrengthTrainings/Graph.cshtml
@@ -1,43 +1,71 @@
-﻿@model string?
+@model LifelogBb.Models.StrengthTrainings.StrengthTrainingGraphViewModel
 
 @{
     ViewData["Title"] = "Strength Training";
-    ViewData["Pretitle"] = "Graph";
-    @if (!string.IsNullOrEmpty(@Model))
-    {
-        ViewData["Pretitle"] = $"{Model} - Graph";
-    }
+    ViewData["Pretitle"] = string.IsNullOrEmpty(Model.SelectedExercise) ? "Graph" : $"{Model.SelectedExercise} - Graph";
+    ViewData["SecondaryAction"] = "table";
 }
 
 <div class="container-xl">
-    <div class="row row-deck row-cards">
+    <div class="row row-cards mb-3">
         <div class="col-12">
             <div class="card">
-                <div class="card-header border-0">
-                    <h3 class="card-title">Total</h3>
-                </div>
                 <div class="card-body">
-                    <div id="strengthtrainingTotal"></div>
+                    <div class="row g-2 align-items-end">
+                        <div class="col-12 col-md-5">
+                            <label class="form-label">Exercise</label>
+                            <select id="exercise-select" class="form-select form-select-lg">
+                                <option value="">All exercises (overview)</option>
+                                @foreach (var exercise in Model.Exercises)
+                                {
+                                    <option value="@exercise" selected="@(exercise == Model.SelectedExercise)">@exercise</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="col-12 col-md-7">
+                            <label class="form-label">Time range</label>
+                            <div class="btn-group w-100" role="group" id="range-buttons">
+                                <button type="button" class="btn" data-range="90">3M</button>
+                                <button type="button" class="btn" data-range="180">6M</button>
+                                <button type="button" class="btn active" data-range="365">1Y</button>
+                                <button type="button" class="btn" data-range="0">All</button>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
-        <div class="col-12">
-            <div class="card">
-                <div class="card-header border-0">
-                    <h3 class="card-title">Weight</h3>
+    </div>
+
+    <div id="exercise-charts">
+        <div class="row row-deck row-cards">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header border-0"><h3 class="card-title">Top set weight per day</h3></div>
+                    <div class="card-body"><div id="chart-top-weight"></div></div>
                 </div>
-                <div class="card-body">
-                    <div id="strengthtrainingWeight"></div>
+            </div>
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header border-0"><h3 class="card-title">Estimated 1RM per day</h3></div>
+                    <div class="card-body"><div id="chart-1rm"></div></div>
+                </div>
+            </div>
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header border-0"><h3 class="card-title">Volume per training day</h3></div>
+                    <div class="card-body"><div id="chart-exercise-volume"></div></div>
                 </div>
             </div>
         </div>
-        <div class="col-12">
-            <div class="card">
-                <div class="card-header border-0">
-                    <h3 class="card-title">Reps</h3>
-                </div>
-                <div class="card-body">
-                    <div id="strengthtrainingReps"></div>
+    </div>
+
+    <div id="overview-charts">
+        <div class="row row-deck row-cards">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header border-0"><h3 class="card-title">Weekly volume &amp; training frequency</h3></div>
+                    <div class="card-body"><div id="chart-weekly-volume"></div></div>
                 </div>
             </div>
         </div>
@@ -45,66 +73,115 @@
 </div>
 
 @section Scripts
-    {
+{
     <script src="~/lib/tabler/core/dist/libs/apexcharts/dist/apexcharts.min.js"></script>
     <script type="text/javascript">
-        function Strengthtraining(data) {
-            this.date = data.createdAt;
-            this.exercise = data.exercise;
-            this.reps = data.reps;
-            this.weight = parseFloat(data.weight).toFixed(2);
-            this.notes = data.notes;
-            this.rating = data.rating;
-        }
+        (function () {
+            var select = document.getElementById('exercise-select');
+            var rangeButtons = document.querySelectorAll('#range-buttons [data-range]');
+            var exerciseCharts = document.getElementById('exercise-charts');
+            var overviewCharts = document.getElementById('overview-charts');
+            var charts = {};
+            var currentRangeDays = 365;
 
-        function generateChart(selDiv, chartTitle, chartData) {
-            var options = {
-                chart: {
-                    type: 'bar'
-                },
-                plotOptions: {
-                },
-                series: [{
-                    name: chartTitle,
-                    data: chartData
-                }],
-                xaxis: {
-                    type: "datetime"
+            function fromDate() {
+                if (currentRangeDays <= 0) return null;
+                var d = new Date();
+                d.setDate(d.getDate() - currentRangeDays);
+                return d.toISOString().slice(0, 10);
+            }
+
+            function renderChart(key, el, options) {
+                if (charts[key]) {
+                    charts[key].destroy();
                 }
-            };
+                charts[key] = new ApexCharts(document.querySelector(el), options);
+                charts[key].render();
+            }
 
-            var chart = new ApexCharts(document.querySelector(`#${selDiv}`), options);
-            chart.render();
-        }
+            function loadExercise(exercise) {
+                exerciseCharts.classList.remove('d-none');
+                overviewCharts.classList.add('d-none');
 
-        $.getJSON("@Url.Action("GraphGet")", { exercise: "@Model" }, function (data) {
-            data = data.sort((a, b) => (a.date > b.date) ? 1 : ((b.date > a.date) ? -1 : 0)); // Ascending!
-            var mappedStrengthtraining = $.map(data, function (item) { return new Strengthtraining(item) });
+                var url = new URL('@Url.Action("GraphExerciseData")', window.location.origin);
+                url.searchParams.set('exercise', exercise);
+                var from = fromDate();
+                if (from) url.searchParams.set('from', from);
 
-            const resultTotal = mappedStrengthtraining.map(sel => {
-                return {
-                    x: sel.date,
-                    y: sel.reps * sel.weight
+                fetch(url).then(function (r) { return r.json(); }).then(function (data) {
+                    var days = data.days || [];
+                    var dates = days.map(function (d) { return d.date; });
+
+                    renderChart('topWeight', '#chart-top-weight', {
+                        chart: { type: 'line', height: 260 },
+                        series: [{ name: 'Top set weight', data: days.map(function (d) { return d.topWeight; }) }],
+                        xaxis: { categories: dates },
+                        markers: { size: 4 },
+                        stroke: { curve: 'straight' }
+                    });
+
+                    renderChart('rm1', '#chart-1rm', {
+                        chart: { type: 'line', height: 260 },
+                        series: [{ name: 'Estimated 1RM', data: days.map(function (d) { return d.est1Rm; }) }],
+                        xaxis: { categories: dates },
+                        markers: { size: 4 },
+                        stroke: { curve: 'straight' }
+                    });
+
+                    renderChart('exerciseVolume', '#chart-exercise-volume', {
+                        chart: { type: 'bar', height: 260 },
+                        series: [{ name: 'Volume', data: days.map(function (d) { return d.volume; }) }],
+                        xaxis: { categories: dates }
+                    });
+                });
+            }
+
+            function loadOverview() {
+                exerciseCharts.classList.add('d-none');
+                overviewCharts.classList.remove('d-none');
+
+                var url = new URL('@Url.Action("GraphOverviewData")', window.location.origin);
+                var from = fromDate();
+                if (from) url.searchParams.set('from', from);
+
+                fetch(url).then(function (r) { return r.json(); }).then(function (data) {
+                    var weeks = data.weeks || [];
+
+                    renderChart('weeklyVolume', '#chart-weekly-volume', {
+                        chart: { height: 300 },
+                        series: [
+                            { name: 'Volume', type: 'column', data: weeks.map(function (w) { return w.volume; }) },
+                            { name: 'Training days', type: 'line', data: weeks.map(function (w) { return w.trainingDays; }) }
+                        ],
+                        xaxis: { categories: weeks.map(function (w) { return w.weekStart; }) },
+                        yaxis: [
+                            { title: { text: 'Volume' } },
+                            { opposite: true, title: { text: 'Training days' }, min: 0 }
+                        ]
+                    });
+                });
+            }
+
+            function load() {
+                if (select.value) {
+                    loadExercise(select.value);
+                } else {
+                    loadOverview();
                 }
+            }
+
+            select.addEventListener('change', load);
+
+            rangeButtons.forEach(function (btn) {
+                btn.addEventListener('click', function () {
+                    rangeButtons.forEach(function (b) { b.classList.remove('active'); });
+                    btn.classList.add('active');
+                    currentRangeDays = parseInt(btn.getAttribute('data-range'), 10);
+                    load();
+                });
             });
 
-            const resultSingle = mappedStrengthtraining.map(sel => {
-                return {
-                    x: sel.date,
-                    y: sel.weight
-                }
-            });
-
-            const resultReps = mappedStrengthtraining.map(sel => {
-                return {
-                    x: sel.date,
-                    y: sel.reps
-                }
-            });
-
-            generateChart("strengthtrainingTotal", "Total by set", resultTotal);
-            generateChart("strengthtrainingWeight", "Weight by set", resultSingle);
-            generateChart("strengthtrainingReps", "Reps by set", resultReps);
-        });
+            load();
+        })();
     </script>
 }

--- a/LifelogBb/Views/StrengthTrainings/Index.cshtml
+++ b/LifelogBb/Views/StrengthTrainings/Index.cshtml
@@ -66,7 +66,7 @@
                             <div class="text-muted">
                                 @if (Model.LastSession != null)
                                 {
-                                    <a asp-action="Details" asp-route-id="@Model.LastSession.Id">@Model.LastSession.CreatedAt.ToString("yyyy-MM-dd")</a>
+                                    <a asp-action="Details" asp-route-id="@Model.LastSession.Id">@Model.LastSession.Date.ToString("yyyy-MM-dd")</a>
                                 }
                                 else
                                 {
@@ -155,7 +155,7 @@
                                 @foreach (var s in Model.RecentSessions)
                                 {
                                     <tr>
-                                        <td><a asp-action="Details" asp-route-id="@s.Id">@s.CreatedAt.ToString("yyyy-MM-dd")</a></td>
+                                        <td><a asp-action="Details" asp-route-id="@s.Id">@s.Date.ToString("yyyy-MM-dd")</a></td>
                                         <td><a asp-action="Graph" asp-route-exercise="@s.Exercise">@s.Exercise</a></td>
                                         <td>@s.Reps</td>
                                         <td>@s.Weight.ToString("0.##") kg</td>

--- a/LifelogBb/Views/StrengthTrainings/Sessions.cshtml
+++ b/LifelogBb/Views/StrengthTrainings/Sessions.cshtml
@@ -1,0 +1,59 @@
+@model List<LifelogBb.Models.StrengthTrainings.StrengthTrainingSession>
+
+@{
+    ViewData["Title"] = "Strength Training";
+    ViewData["Pretitle"] = "Sessions";
+    ViewData["SecondaryAction"] = "graph";
+}
+
+<div class="container-xl">
+    @if (Model.Count == 0)
+    {
+        <div class="row row-cards">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-body text-center text-muted py-5">
+                        No sessions logged yet. <a asp-action="Create">Add your first session</a>.
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
+    else
+    {
+        <div class="row row-cards">
+            @foreach (var session in Model)
+            {
+                <div class="col-12">
+                    <div class="card">
+                        <div class="card-body">
+                            <div class="row align-items-center">
+                                <div class="col-auto">
+                                    <span class="bg-primary text-white avatar"><i class="fa-solid fa-dumbbell"></i></span>
+                                </div>
+                                <div class="col">
+                                    <div class="d-flex justify-content-between">
+                                        <div>
+                                            <div class="font-weight-medium">@session.Date.ToString("dddd, yyyy-MM-dd")</div>
+                                            <div class="text-secondary">@session.SetCount sets &middot; @session.Volume.ToString("N0") kg volume &middot; @string.Join(", ", session.Exercises)</div>
+                                        </div>
+                                        <div class="text-end">
+                                            @if (session.TrainingPlanId != null)
+                                            {
+                                                <a class="badge bg-blue-lt" asp-controller="TrainingPlans" asp-action="Details" asp-route-id="@session.TrainingPlanId">@session.TrainingPlanName</a>
+                                                @if (session.CompletionRate != null)
+                                                {
+                                                    <div class="text-secondary small mt-1">@((session.CompletionRate.Value * 100).ToString("0")) % completed</div>
+                                                }
+                                            }
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+    }
+</div>

--- a/LifelogBb/Views/StrengthTrainings/Table.cshtml
+++ b/LifelogBb/Views/StrengthTrainings/Table.cshtml
@@ -22,7 +22,7 @@
                         <thead>
                             <tr>
                                 <th class="w-1">
-                                    <a asp-action="Table" asp-route-sortOrder="@RazorPageExtensions.GetSortRoute(ViewData, "CreatedAt")" asp-route-currentFilter="@ViewData["CurrentFilter"]" asp-route-filter="@ViewData["Filter"]" class="table-sort @RazorPageExtensions.GetSortOrder(ViewData, "CreatedAt")">Date</a>
+                                    <a asp-action="Table" asp-route-sortOrder="@RazorPageExtensions.GetSortRoute(ViewData, "Date")" asp-route-currentFilter="@ViewData["CurrentFilter"]" asp-route-filter="@ViewData["Filter"]" class="table-sort @RazorPageExtensions.GetSortOrder(ViewData, "Date")">Date</a>
                                 </th>
                                 <th>
                                     <a asp-action="Table" asp-route-sortOrder="@RazorPageExtensions.GetSortRoute(ViewData, "Exercise")" asp-route-currentFilter="@ViewData["CurrentFilter"]" asp-route-filter="@ViewData["Filter"]" class="table-sort @RazorPageExtensions.GetSortOrder(ViewData, "Exercise")">Exercise</a>
@@ -50,7 +50,7 @@
                             {
                                 <tr>
                                     <th scope="row">
-                                        <a asp-action="Details" asp-route-id="@item.Id">@Html.DisplayFor(modelItem => item.CreatedAt)</a>
+                                        <a asp-action="Details" asp-route-id="@item.Id">@item.Date.ToString("yyyy-MM-dd")</a>
                                     </th>
                                     <td>
                                         <a asp-action="Graph" asp-route-exercise="@item.Exercise">@Html.DisplayFor(modelItem => item.Exercise)</a>

--- a/LifelogBb/Views/TrainingPlans/Copy.cshtml
+++ b/LifelogBb/Views/TrainingPlans/Copy.cshtml
@@ -1,0 +1,39 @@
+@model LifelogBb.Controllers.CopyTrainingPlanViewModel
+
+@{
+    ViewData["Title"] = "Training Plans";
+    ViewData["Pretitle"] = "Copy";
+}
+
+<div class="container-xl">
+    <div class="row row-cards">
+        <div class="col-12">
+            <form asp-action="Copy" class="card">
+                <div class="card-header">
+                    <h3 class="card-title">Copy "@ViewData["SourceName"]"</h3>
+                </div>
+                <div class="card-body">
+                    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                    <div class="form-group mb-3">
+                        <label asp-for="Name" class="control-label mb-1"></label>
+                        <input asp-for="Name" class="form-control form-control-lg" />
+                        <span asp-validation-for="Name" class="text-danger"></span>
+                    </div>
+                    <div class="form-group mb-3">
+                        <label asp-for="Date" class="control-label mb-1"></label>
+                        <input asp-for="Date" type="date" class="form-control form-control-lg" />
+                        <div class="form-hint">Leave empty to create another base plan. Set a date to create a plan for that specific day.</div>
+                        <span asp-validation-for="Date" class="text-danger"></span>
+                    </div>
+                    <input type="hidden" asp-for="SourceId" />
+                </div>
+                <div class="card-footer text-end">
+                    <div class="d-flex">
+                        <a class="btn btn-secondary" asp-action="Index"><i class="fas fa-arrow-circle-left icon"></i>Back</a>
+                        <button type="submit" value="Copy" class="btn btn-primary ms-auto"><i class="fas fa-copy icon"></i>Copy</button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/LifelogBb/Views/TrainingPlans/Create.cshtml
+++ b/LifelogBb/Views/TrainingPlans/Create.cshtml
@@ -1,0 +1,55 @@
+@model LifelogBb.Models.TrainingPlans.EditTrainingPlanViewModel
+
+@{
+    ViewData["Title"] = "Training Plans";
+    ViewData["Pretitle"] = "Create";
+}
+
+<div class="container-xl">
+    <div class="row row-cards">
+        <div class="col-12">
+            <form asp-action="Create" class="card">
+                <div class="card-body">
+                    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                    <div class="form-group mb-3">
+                        <label asp-for="Name" class="control-label mb-1"></label>
+                        <input asp-for="Name" class="form-control form-control-lg" />
+                        <span asp-validation-for="Name" class="text-danger"></span>
+                    </div>
+                    <div class="form-group mb-3">
+                        <label asp-for="Description" class="control-label mb-1"></label>
+                        <input asp-for="Description" class="form-control form-control-lg" />
+                        <span asp-validation-for="Description" class="text-danger"></span>
+                    </div>
+                    <div class="form-group mb-3">
+                        <label asp-for="Date" class="control-label mb-1"></label>
+                        <input asp-for="Date" type="date" class="form-control form-control-lg" />
+                        <div class="form-hint">Leave empty for a reusable base plan. Set a date to make this a plan for that specific day.</div>
+                        <span asp-validation-for="Date" class="text-danger"></span>
+                    </div>
+                    <div class="form-check form-switch mb-3">
+                        <input asp-for="IsArchived" class="form-check-input" type="checkbox" />
+                        <label asp-for="IsArchived" class="form-check-label"></label>
+                    </div>
+                    <div class="form-group mb-3">
+                        @Html.EditorFor(model => model.SetsJson, "PlanSets")
+                        <span asp-validation-for="SetsJson" class="text-danger"></span>
+                    </div>
+                </div>
+                <div class="card-footer text-end">
+                    <div class="d-flex">
+                        <a class="btn btn-secondary" asp-action="Index"><i class="fas fa-arrow-circle-left icon"></i>Back</a>
+                        <button type="submit" value="Create" class="btn btn-primary ms-auto"><i class="fas fa-plus-square icon"></i>Submit</button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script src="~/js/plansetseditor.js"></script>
+    @{
+        await Html.RenderPartialAsync("_ValidationScriptsPartial");
+    }
+}

--- a/LifelogBb/Views/TrainingPlans/Delete.cshtml
+++ b/LifelogBb/Views/TrainingPlans/Delete.cshtml
@@ -1,0 +1,31 @@
+@model LifelogBb.Models.Entities.TrainingPlan
+
+@{
+    ViewData["Title"] = "Training Plans";
+    ViewData["Pretitle"] = "Delete";
+}
+
+<div class="container-xl">
+    <div class="row row-cards">
+        <div class="col-12">
+            <form asp-action="Delete" class="card">
+                <div class="card-header">
+                    <h3 class="card-title">Are you sure you want to delete "@Model.Name"?</h3>
+                </div>
+                <div class="card-body">
+                    <p class="text-secondary">
+                        This deletes the plan and its @Model.Sets.Count planned set@(Model.Sets.Count == 1 ? "" : "s").
+                        Strength trainings already logged against it are kept; only the link to this plan is cleared.
+                    </p>
+                </div>
+                <input type="hidden" asp-for="Id" />
+                <div class="card-footer text-end">
+                    <div class="d-flex">
+                        <a class="btn btn-secondary" asp-action="Index"><i class="fas fa-arrow-circle-left icon"></i>Back</a>
+                        <button type="submit" value="Delete" class="btn btn-danger ms-auto"><i class="fas fa-trash icon"></i>Delete</button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/LifelogBb/Views/TrainingPlans/Details.cshtml
+++ b/LifelogBb/Views/TrainingPlans/Details.cshtml
@@ -1,0 +1,114 @@
+@model LifelogBb.Models.TrainingPlans.TrainingPlanDetailsViewModel
+
+@{
+    ViewData["Title"] = "Training Plans";
+    ViewData["Pretitle"] = "Details";
+}
+
+<div class="container-xl">
+    <div class="row row-cards">
+        <div class="col-12">
+            <div class="card">
+                <div class="card-header border-0">
+                    <h3 class="card-title">@Model.Plan.Name</h3>
+                    @if (Model.Plan.Date != null)
+                    {
+                        <div class="card-options text-muted">@Model.Plan.Date.Value.ToString("yyyy-MM-dd")</div>
+                    }
+                </div>
+                <div class="card-body pt-0">
+                    @if (!string.IsNullOrEmpty(Model.Plan.Description))
+                    {
+                        <p>@Model.Plan.Description</p>
+                    }
+
+                    @if (Model.TotalCount > 0)
+                    {
+                        <div class="mb-3">
+                            <div class="d-flex justify-content-between mb-1">
+                                <span>Completed</span>
+                                <span>@Model.DoneCount / @Model.TotalCount (@((Model.CompletionRate * 100).ToString("0")) %)</span>
+                            </div>
+                            <div class="progress">
+                                <div class="progress-bar bg-success" style="width: @((Model.CompletionRate * 100).ToString("0", System.Globalization.CultureInfo.InvariantCulture))%"></div>
+                            </div>
+                        </div>
+                    }
+
+                    <div class="table-responsive">
+                        <table class="table table-vcenter">
+                            <thead>
+                                <tr>
+                                    <th>#</th>
+                                    <th>Exercise</th>
+                                    <th>Planned</th>
+                                    <th>Actual</th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @{ var i = 1; }
+                                @foreach (var row in Model.Rows)
+                                {
+                                    <tr>
+                                        <td>@i</td>
+                                        <td>@row.Planned.Exercise</td>
+                                        <td>@row.Planned.Reps &times; @row.Planned.Weight.ToString("0.##") kg</td>
+                                        <td>
+                                            @if (row.Actual != null)
+                                            {
+                                                @: @row.Actual.Reps &times; @row.Actual.Weight.ToString("0.##") kg
+                                            }
+                                            else
+                                            {
+                                                <span class="text-muted">not done yet</span>
+                                            }
+                                        </td>
+                                        <td>
+                                            @if (row.Actual != null)
+                                            {
+                                                <span class="badge bg-success-lt"><i class="fas fa-check icon m-0"></i></span>
+                                            }
+                                        </td>
+                                    </tr>
+                                    i++;
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+
+                    @if (Model.ExtraTrainings.Count > 0)
+                    {
+                        <h4 class="mt-4">Extra sets (not in plan)</h4>
+                        <div class="table-responsive">
+                            <table class="table table-vcenter">
+                                <thead>
+                                    <tr><th>Exercise</th><th>Reps</th><th>Weight</th></tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (var extra in Model.ExtraTrainings)
+                                    {
+                                        <tr>
+                                            <td><a asp-controller="StrengthTrainings" asp-action="Details" asp-route-id="@extra.Id">@extra.Exercise</a></td>
+                                            <td>@extra.Reps</td>
+                                            <td>@extra.Weight.ToString("0.##") kg</td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    }
+                </div>
+                <div class="card-footer text-end">
+                    <div class="d-flex">
+                        <a class="btn btn-secondary" asp-action="Index"><i class="fas fa-arrow-circle-left icon"></i>Back</a>
+                        <a class="btn btn-danger ms-auto" asp-action="Delete" asp-route-id="@Model.Plan.Id"><i class="fas fa-trash icon"></i> Delete</a>
+                        <a class="btn btn-outline-secondary" asp-action="Copy" asp-route-id="@Model.Plan.Id"><i class="fas fa-copy icon"></i> Copy</a>
+                        <a class="btn btn-dark" asp-action="Edit" asp-route-id="@Model.Plan.Id"><i class="fas fa-pen icon"></i> Edit</a>
+                        <a class="btn btn-primary" asp-action="Workout" asp-route-id="@Model.Plan.Id"><i class="fas fa-play icon"></i> Start workout</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/LifelogBb/Views/TrainingPlans/Details.cshtml
+++ b/LifelogBb/Views/TrainingPlans/Details.cshtml
@@ -100,12 +100,19 @@
                     }
                 </div>
                 <div class="card-footer text-end">
-                    <div class="d-flex">
+                    <div class="d-flex gap-2">
                         <a class="btn btn-secondary" asp-action="Index"><i class="fas fa-arrow-circle-left icon"></i>Back</a>
                         <a class="btn btn-danger ms-auto" asp-action="Delete" asp-route-id="@Model.Plan.Id"><i class="fas fa-trash icon"></i> Delete</a>
                         <a class="btn btn-outline-secondary" asp-action="Copy" asp-route-id="@Model.Plan.Id"><i class="fas fa-copy icon"></i> Copy</a>
                         <a class="btn btn-dark" asp-action="Edit" asp-route-id="@Model.Plan.Id"><i class="fas fa-pen icon"></i> Edit</a>
-                        <a class="btn btn-primary" asp-action="Workout" asp-route-id="@Model.Plan.Id"><i class="fas fa-play icon"></i> Start workout</a>
+                        @if (Model.Plan.Date == null)
+                        {
+                            <a class="btn btn-primary" asp-action="Workout" asp-route-id="@Model.Plan.Id"><i class="fas fa-play icon"></i> Start workout</a>
+                        }
+                        else
+                        {
+                            <a class="btn btn-primary" asp-action="Workout" asp-route-id="@Model.Plan.Id"><i class="fas fa-forward icon"></i> Resume workout</a>
+                        }
                     </div>
                 </div>
             </div>

--- a/LifelogBb/Views/TrainingPlans/Edit.cshtml
+++ b/LifelogBb/Views/TrainingPlans/Edit.cshtml
@@ -1,0 +1,56 @@
+@model LifelogBb.Models.TrainingPlans.EditTrainingPlanViewModel
+
+@{
+    ViewData["Title"] = "Training Plans";
+    ViewData["Pretitle"] = "Edit";
+}
+
+<div class="container-xl">
+    <div class="row row-cards">
+        <div class="col-12">
+            <form asp-action="Edit" class="card">
+                <div class="card-body">
+                    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                    <div class="form-group mb-3">
+                        <label asp-for="Name" class="control-label mb-1"></label>
+                        <input asp-for="Name" class="form-control form-control-lg" />
+                        <span asp-validation-for="Name" class="text-danger"></span>
+                    </div>
+                    <div class="form-group mb-3">
+                        <label asp-for="Description" class="control-label mb-1"></label>
+                        <input asp-for="Description" class="form-control form-control-lg" />
+                        <span asp-validation-for="Description" class="text-danger"></span>
+                    </div>
+                    <div class="form-group mb-3">
+                        <label asp-for="Date" class="control-label mb-1"></label>
+                        <input asp-for="Date" type="date" class="form-control form-control-lg" />
+                        <div class="form-hint">Leave empty for a reusable base plan. Set a date to make this a plan for that specific day.</div>
+                        <span asp-validation-for="Date" class="text-danger"></span>
+                    </div>
+                    <div class="form-check form-switch mb-3">
+                        <input asp-for="IsArchived" class="form-check-input" type="checkbox" />
+                        <label asp-for="IsArchived" class="form-check-label"></label>
+                    </div>
+                    <div class="form-group mb-3">
+                        @Html.EditorFor(model => model.SetsJson, "PlanSets")
+                        <span asp-validation-for="SetsJson" class="text-danger"></span>
+                    </div>
+                    <input type="hidden" asp-for="Id" />
+                </div>
+                <div class="card-footer text-end">
+                    <div class="d-flex">
+                        <a class="btn btn-secondary" asp-action="Index"><i class="fas fa-arrow-circle-left icon"></i>Back</a>
+                        <button type="submit" value="Save" class="btn btn-primary ms-auto"><i class="fas fa-pen icon"></i>Submit</button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script src="~/js/plansetseditor.js"></script>
+    @{
+        await Html.RenderPartialAsync("_ValidationScriptsPartial");
+    }
+}

--- a/LifelogBb/Views/TrainingPlans/Index.cshtml
+++ b/LifelogBb/Views/TrainingPlans/Index.cshtml
@@ -1,0 +1,37 @@
+@using LifelogBb.Models.TrainingPlans
+@model TrainingPlanIndexViewModel
+
+@{
+    ViewData["Title"] = "Training Plans";
+    ViewData["PrimaryAction"] = "create";
+}
+
+<div class="container-xl">
+    @{ await Html.RenderPartialAsync("_PlanSection", new PlanSectionModel("Templates", "Reusable base plans. Start a workout from one to create today's copy.", Model.Templates, showStart: true)); }
+    @{ await Html.RenderPartialAsync("_PlanSection", new PlanSectionModel("Day plans", "Concrete plans for a specific day.", Model.DayPlans, showStart: true)); }
+
+    @if (Model.Archived.Count > 0)
+    {
+        <div class="mb-3">
+            <a class="text-secondary" data-bs-toggle="collapse" href="#archivedPlans" role="button">
+                <i class="fas fa-box-archive icon"></i> Archived (@Model.Archived.Count)
+            </a>
+            <div class="collapse mt-2" id="archivedPlans">
+                @{ await Html.RenderPartialAsync("_PlanSection", new PlanSectionModel(null, null, Model.Archived, showStart: false)); }
+            </div>
+        </div>
+    }
+
+    @if (Model.Templates.Count == 0 && Model.DayPlans.Count == 0 && Model.Archived.Count == 0)
+    {
+        <div class="row row-cards">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-body text-center text-muted py-5">
+                        No training plans yet. <a asp-action="Create">Create your first plan</a>.
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
+</div>

--- a/LifelogBb/Views/TrainingPlans/Table.cshtml
+++ b/LifelogBb/Views/TrainingPlans/Table.cshtml
@@ -1,0 +1,75 @@
+@using LifelogBb.Utilities;
+@model PaginatedListViewModel<LifelogBb.Models.Entities.TrainingPlan>
+
+@{
+    ViewData["Title"] = "Training Plans";
+    ViewData["PrimaryAction"] = "create";
+}
+
+@section Styles
+{
+    <link rel="stylesheet" href="~/lib/jquery-querybuilder/css/query-builder.default.css" />
+}
+<div class="container-xl">
+    @await Component.InvokeAsync("FilterBuilder", new { entityType = typeof(LifelogBb.Models.Entities.TrainingPlan), currentFilter = ViewData["Filter"] as string })
+    <div class="row row-cards">
+        <div class="col-12">
+            <div class="card">
+                <div class="table-responsive">
+                    <table class="table card-table table-vcenter text-nowrap datatable">
+                        <thead>
+                            <tr>
+                                <th class="w-1">
+                                    <a asp-action="Table" asp-route-sortOrder="@RazorPageExtensions.GetSortRoute(ViewData, "CreatedAt")" asp-route-currentFilter="@ViewData["CurrentFilter"]" asp-route-filter="@ViewData["Filter"]" class="table-sort @RazorPageExtensions.GetSortOrder(ViewData, "CreatedAt")">Created</a>
+                                </th>
+                                <th>
+                                    <a asp-action="Table" asp-route-sortOrder="@RazorPageExtensions.GetSortRoute(ViewData, "Name")" asp-route-currentFilter="@ViewData["CurrentFilter"]" asp-route-filter="@ViewData["Filter"]" class="table-sort @RazorPageExtensions.GetSortOrder(ViewData, "Name")">Name</a>
+                                </th>
+                                <th>
+                                    <a asp-action="Table" asp-route-sortOrder="@RazorPageExtensions.GetSortRoute(ViewData, "Date")" asp-route-currentFilter="@ViewData["CurrentFilter"]" asp-route-filter="@ViewData["Filter"]" class="table-sort @RazorPageExtensions.GetSortOrder(ViewData, "Date")">Date</a>
+                                </th>
+                                <th>Sets</th>
+                                <th>
+                                    <a asp-action="Table" asp-route-sortOrder="@RazorPageExtensions.GetSortRoute(ViewData, "IsArchived")" asp-route-currentFilter="@ViewData["CurrentFilter"]" asp-route-filter="@ViewData["Filter"]" class="table-sort @RazorPageExtensions.GetSortOrder(ViewData, "IsArchived")">Archived</a>
+                                </th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var item in Model.List)
+                            {
+                                <tr>
+                                    <th scope="row">
+                                        <a asp-action="Details" asp-route-id="@item.Id">@Html.DisplayFor(modelItem => item.CreatedAt)</a>
+                                    </th>
+                                    <td>@item.Name</td>
+                                    <td>@(item.Date != null ? item.Date.Value.ToString("yyyy-MM-dd") : "—")</td>
+                                    <td>@item.Sets.Count</td>
+                                    <td>@(item.IsArchived ? "Yes" : "No")</td>
+                                    <td class="text-end">
+                                        <div class="dropdown">
+                                            <button class="btn dropdown-toggle align-text-top" data-bs-boundary="viewport" data-bs-toggle="dropdown">Actions</button>
+                                            <div class="dropdown-menu dropdown-menu-end">
+                                                <a class="dropdown-item" asp-action="Edit" asp-route-id="@item.Id">Edit</a>
+                                                <a class="dropdown-item" asp-action="Copy" asp-route-id="@item.Id">Copy</a>
+                                                <a class="dropdown-item text-danger" asp-action="Delete" asp-route-id="@item.Id">Delete</a>
+                                            </div>
+                                        </div>
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+                <div class="card-footer d-flex align-items-center">
+                    @await Component.InvokeAsync("Pagination", Model.List)
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts
+{
+    <script src="~/lib/jquery-querybuilder/js/query-builder.standalone.js"></script>
+}

--- a/LifelogBb/Views/TrainingPlans/Workout.cshtml
+++ b/LifelogBb/Views/TrainingPlans/Workout.cshtml
@@ -1,0 +1,147 @@
+@model LifelogBb.Models.TrainingPlans.WorkoutViewModel
+
+@{
+    ViewData["Title"] = "Training Plans";
+    ViewData["Pretitle"] = "Workout";
+}
+
+<div class="container-xl">
+    @Html.AntiForgeryToken()
+    <div class="row row-cards mb-3">
+        <div class="col-12">
+            <div class="card">
+                <div class="card-body">
+                    <h2 class="mb-1">@Model.Plan.Name</h2>
+                    @if (Model.Plan.Date != null)
+                    {
+                        <div class="text-secondary mb-2">@Model.Plan.Date.Value.ToString("yyyy-MM-dd")</div>
+                    }
+                    <div class="d-flex justify-content-between mb-1">
+                        <span id="workout-progress-label">@Model.DoneCount / @Model.TotalCount sets done</span>
+                    </div>
+                    <div class="progress">
+                        <div class="progress-bar bg-success" id="workout-progress-bar" style="width: @(Model.TotalCount == 0 ? 0 : (Model.DoneCount * 100 / Model.TotalCount))%"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row row-cards" id="workout-set-list">
+        @{ var index = 1; }
+        @foreach (var row in Model.Rows)
+        {
+            <div class="col-12" data-workout-set-card data-plan-set-id="@row.Planned.Id" data-training-id="@(row.Actual?.Id)">
+                <div class="card @(row.Actual != null ? "bg-success-lt" : "")">
+                    <div class="card-body">
+                        <div class="d-flex justify-content-between align-items-start mb-2">
+                            <div>
+                                <div class="text-secondary small">Set @index</div>
+                                <h3 class="mb-0">@row.Planned.Exercise</h3>
+                                <div class="text-secondary">Planned: @row.Planned.Reps &times; @row.Planned.Weight.ToString("0.##") kg</div>
+                            </div>
+                            <div data-workout-set-done-badge class="@(row.Actual == null ? "d-none" : "")">
+                                <span class="badge bg-success"><i class="fas fa-check icon m-0"></i> Done</span>
+                            </div>
+                        </div>
+                        <div data-workout-set-pending class="@(row.Actual != null ? "d-none" : "")">
+                            <div class="row g-2 align-items-end">
+                                <div class="col-5 col-md-3">
+                                    <label class="form-label small mb-1">Reps</label>
+                                    <input type="number" min="0" class="form-control form-control-lg" data-workout-reps value="@row.Planned.Reps" />
+                                </div>
+                                <div class="col-5 col-md-3">
+                                    <label class="form-label small mb-1">Weight</label>
+                                    <input type="number" min="0" step="0.5" class="form-control form-control-lg" data-workout-weight value="@row.Planned.Weight.ToString(System.Globalization.CultureInfo.InvariantCulture)" />
+                                </div>
+                                <div class="col-2 col-md-6 text-end">
+                                    <button type="button" class="btn btn-lg btn-success w-100" data-workout-confirm><i class="fas fa-check icon"></i> Done</button>
+                                </div>
+                            </div>
+                        </div>
+                        <div data-workout-set-done class="@(row.Actual == null ? "d-none" : "")">
+                            <span data-workout-actual-text>
+                                @if (row.Actual != null)
+                                {
+                                    @: @row.Actual.Reps &times; @row.Actual.Weight.ToString("0.##") kg
+                                }
+                            </span>
+                            <button type="button" class="btn btn-sm btn-outline-secondary ms-2" data-workout-undo><i class="fas fa-rotate-left icon"></i> Undo</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            index++;
+        }
+    </div>
+
+    <div class="row row-cards mt-3">
+        <div class="col-12 d-flex">
+            <a class="btn btn-secondary" asp-controller="StrengthTrainings" asp-action="Create">Log extra set</a>
+            <a class="btn btn-primary ms-auto" asp-action="Details" asp-route-id="@Model.Plan.Id">Finish</a>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script>
+        (function () {
+            var token = document.querySelector('input[name="__RequestVerificationToken"]').value;
+            var totalSets = @Model.TotalCount;
+
+            function updateProgress() {
+                var done = document.querySelectorAll('[data-workout-set-card][data-training-id]:not([data-training-id=""])').length;
+                document.getElementById('workout-progress-label').textContent = done + ' / ' + totalSets + ' sets done';
+                document.getElementById('workout-progress-bar').style.width = (totalSets === 0 ? 0 : (done * 100 / totalSets)) + '%';
+            }
+
+            document.querySelectorAll('[data-workout-set-card]').forEach(function (card) {
+                var planSetId = card.getAttribute('data-plan-set-id');
+
+                card.querySelector('[data-workout-confirm]').addEventListener('click', function () {
+                    var reps = parseInt(card.querySelector('[data-workout-reps]').value, 10) || 0;
+                    var weight = parseFloat(card.querySelector('[data-workout-weight]').value) || 0;
+
+                    fetch('@Url.Action("WorkoutConfirmSet")', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json', 'RequestVerificationToken': token },
+                        body: JSON.stringify({ planSetId: planSetId, reps: reps, weight: weight, rating: 3 })
+                    })
+                        .then(function (r) { return r.json(); })
+                        .then(function (data) {
+                            if (!data.ok) return;
+                            card.setAttribute('data-training-id', data.trainingId);
+                            card.querySelector('.card').classList.add('bg-success-lt');
+                            card.querySelector('[data-workout-set-done-badge]').classList.remove('d-none');
+                            card.querySelector('[data-workout-set-pending]').classList.add('d-none');
+                            var doneEl = card.querySelector('[data-workout-set-done]');
+                            doneEl.classList.remove('d-none');
+                            doneEl.querySelector('[data-workout-actual-text]').textContent = reps + ' × ' + weight + ' kg';
+                            updateProgress();
+                        });
+                });
+
+                card.querySelector('[data-workout-undo]').addEventListener('click', function () {
+                    var trainingId = card.getAttribute('data-training-id');
+                    if (!trainingId) return;
+
+                    fetch('@Url.Action("WorkoutUndoSet")', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json', 'RequestVerificationToken': token },
+                        body: JSON.stringify({ trainingId: trainingId })
+                    })
+                        .then(function (r) { return r.json(); })
+                        .then(function (data) {
+                            if (!data.ok) return;
+                            card.setAttribute('data-training-id', '');
+                            card.querySelector('.card').classList.remove('bg-success-lt');
+                            card.querySelector('[data-workout-set-done-badge]').classList.add('d-none');
+                            card.querySelector('[data-workout-set-pending]').classList.remove('d-none');
+                            card.querySelector('[data-workout-set-done]').classList.add('d-none');
+                            updateProgress();
+                        });
+                });
+            });
+        })();
+    </script>
+}

--- a/LifelogBb/Views/TrainingPlans/_PlanSection.cshtml
+++ b/LifelogBb/Views/TrainingPlans/_PlanSection.cshtml
@@ -1,0 +1,52 @@
+@model LifelogBb.Models.TrainingPlans.PlanSectionModel
+
+@if (Model.Plans.Count == 0 && Model.Title != null)
+{
+    return;
+}
+
+<div class="mb-3">
+    @if (Model.Title != null)
+    {
+        <h3 class="mb-1">@Model.Title</h3>
+        @if (Model.Subtitle != null)
+        {
+            <div class="text-secondary mb-2">@Model.Subtitle</div>
+        }
+    }
+    <div class="row row-cards">
+        @foreach (var plan in Model.Plans)
+        {
+            <div class="col-sm-6 col-lg-4">
+                <div class="card h-100">
+                    <div class="card-header border-0">
+                        <h3 class="card-title">
+                            <a asp-action="Details" asp-route-id="@plan.Id" class="text-reset">@plan.Name</a>
+                        </h3>
+                        @if (plan.Date != null)
+                        {
+                            <div class="card-options text-muted small">@plan.Date.Value.ToString("yyyy-MM-dd")</div>
+                        }
+                    </div>
+                    <div class="card-body pt-0">
+                        <div class="text-secondary">@plan.Sets.Count set@(plan.Sets.Count == 1 ? "" : "s"), @plan.Sets.Select(s => s.Exercise).Distinct().Count() exercise@(plan.Sets.Select(s => s.Exercise).Distinct().Count() == 1 ? "" : "s")</div>
+                        @if (!string.IsNullOrEmpty(plan.Description))
+                        {
+                            <div class="text-truncate mt-1">@plan.Description</div>
+                        }
+                    </div>
+                    <div class="card-footer">
+                        <div class="btn-list">
+                            @if (Model.ShowStart)
+                            {
+                                <a asp-action="Workout" asp-route-id="@plan.Id" class="btn btn-sm btn-primary"><i class="fas fa-play icon"></i>Start workout</a>
+                            }
+                            <a asp-action="Edit" asp-route-id="@plan.Id" class="btn btn-sm btn-outline-secondary"><i class="fas fa-pen icon"></i></a>
+                            <a asp-action="Copy" asp-route-id="@plan.Id" class="btn btn-sm btn-outline-secondary"><i class="fas fa-copy icon"></i></a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        }
+    </div>
+</div>

--- a/LifelogBb/Views/TrainingPlans/_PlanSection.cshtml
+++ b/LifelogBb/Views/TrainingPlans/_PlanSection.cshtml
@@ -39,7 +39,14 @@
                         <div class="btn-list">
                             @if (Model.ShowStart)
                             {
-                                <a asp-action="Workout" asp-route-id="@plan.Id" class="btn btn-sm btn-primary"><i class="fas fa-play icon"></i>Start workout</a>
+                                @if (plan.Date == null)
+                                {
+                                    <a asp-action="Workout" asp-route-id="@plan.Id" class="btn btn-sm btn-primary"><i class="fas fa-play icon"></i>Start workout</a>
+                                }
+                                else
+                                {
+                                    <a asp-action="Workout" asp-route-id="@plan.Id" class="btn btn-sm btn-primary"><i class="fas fa-forward icon"></i>Resume workout</a>
+                                }
                             }
                             <a asp-action="Edit" asp-route-id="@plan.Id" class="btn btn-sm btn-outline-secondary"><i class="fas fa-pen icon"></i></a>
                             <a asp-action="Copy" asp-route-id="@plan.Id" class="btn btn-sm btn-outline-secondary"><i class="fas fa-copy icon"></i></a>

--- a/LifelogBb/wwwroot/js/plansetseditor.js
+++ b/LifelogBb/wwwroot/js/plansetseditor.js
@@ -1,0 +1,101 @@
+// Repeatable training plan set row editor. Serializes to a JSON array of
+// { exercise, reps, weight, notes } into the editor's hidden SetsJson input. Scoped to each
+// [data-plan-set-editor] container instead of using global ids, so more than one could exist on a page.
+// Exercise autocomplete uses a plain <datalist> (see PlanSets.cshtml) instead of Tagify, since Tagify
+// would need per-row re-initialization after each clone from the <template>.
+
+document.addEventListener("DOMContentLoaded", function () {
+  var editors = document.querySelectorAll("[data-plan-set-editor]");
+
+  editors.forEach(function (editor) {
+    var hiddenInput = editor.querySelector("#SetsJson") || editor.querySelector('input[name="SetsJson"]');
+    var rowsContainer = editor.querySelector("[data-plan-set-rows]");
+    var emptyText = editor.querySelector("[data-plan-set-empty]");
+    var template = editor.querySelector("[data-plan-set-template]");
+
+    function updateEmptyState() {
+      var hasRows = rowsContainer.querySelectorAll("[data-plan-set-row]").length > 0;
+      emptyText.hidden = hasRows;
+    }
+
+    function serialize() {
+      var rows = rowsContainer.querySelectorAll("[data-plan-set-row]");
+      var parts = [];
+      rows.forEach(function (row) {
+        parts.push({
+          exercise: row.querySelector("[data-plan-set-exercise]").value.trim(),
+          reps: parseInt(row.querySelector("[data-plan-set-reps]").value, 10) || 0,
+          weight: parseFloat(row.querySelector("[data-plan-set-weight]").value) || 0,
+          notes: row.querySelector("[data-plan-set-notes]").value.trim() || null
+        });
+      });
+      hiddenInput.value = JSON.stringify(parts);
+      updateEmptyState();
+    }
+
+    function addRow(data, afterRow) {
+      var fragment = template.content.cloneNode(true);
+      var row = fragment.querySelector("[data-plan-set-row]");
+      var exerciseInput = row.querySelector("[data-plan-set-exercise]");
+      var repsInput = row.querySelector("[data-plan-set-reps]");
+      var weightInput = row.querySelector("[data-plan-set-weight]");
+      var notesInput = row.querySelector("[data-plan-set-notes]");
+
+      exerciseInput.value = (data && data.exercise) || "";
+      repsInput.value = (data && data.reps) || 10;
+      weightInput.value = (data && data.weight) || 0;
+      notesInput.value = (data && data.notes) || "";
+
+      [exerciseInput, repsInput, weightInput, notesInput].forEach(function (input) {
+        input.addEventListener("input", serialize);
+      });
+
+      row.querySelector("[data-plan-set-remove]").addEventListener("click", function () {
+        row.remove();
+        serialize();
+      });
+
+      row.querySelector("[data-plan-set-up]").addEventListener("click", function () {
+        var prev = row.previousElementSibling;
+        if (prev) rowsContainer.insertBefore(row, prev);
+        serialize();
+      });
+
+      row.querySelector("[data-plan-set-down]").addEventListener("click", function () {
+        var next = row.nextElementSibling;
+        if (next) rowsContainer.insertBefore(next, row);
+        serialize();
+      });
+
+      row.querySelector("[data-plan-set-duplicate]").addEventListener("click", function () {
+        addRow({
+          exercise: exerciseInput.value,
+          reps: parseInt(repsInput.value, 10) || 0,
+          weight: parseFloat(weightInput.value) || 0,
+          notes: notesInput.value
+        }, row);
+        serialize();
+      });
+
+      if (afterRow && afterRow.nextSibling) {
+        rowsContainer.insertBefore(row, afterRow.nextSibling);
+      } else {
+        rowsContainer.appendChild(row);
+      }
+    }
+
+    editor.querySelector("[data-plan-set-add]").addEventListener("click", function () {
+      addRow(null);
+      serialize();
+    });
+
+    // Seed rows from the hidden input's initial JSON value.
+    try {
+      var initial = hiddenInput.value ? JSON.parse(hiddenInput.value) : [];
+      initial.forEach(function (entry) { addRow(entry); });
+    } catch (e) {
+      // Malformed JSON: start from an empty set list rather than failing to render the page.
+    }
+    updateEmptyState();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a `TrainingPlan`/`TrainingPlanSet` model: reusable base plans (no date) or concrete day plans (dated), one row per planned set, editable via a dynamic set editor and copyable from the UI, REST API (`POST /api/trainingplans/{id}/copy`), and new MCP tools (`GetAllTrainingPlans`, `CreateTrainingPlan`, `UpdateTrainingPlan`, `DeleteTrainingPlan`, `CopyTrainingPlan`).
- Adds a one-tap "Workout" capture view: starting a workout from a template creates a dated copy for today, each planned set is confirmed via AJAX (values prefilled, adjustable), and the done state is derived from the database so a page reload mid-workout resumes correctly.
- Logged `StrengthTraining` rows can now link back to the plan and specific planned set they fulfilled (`TrainingPlanId`/`TrainingPlanSetId`, both nullable, `SetNull` on delete), enabling planned-vs-actual comparison without losing history when a plan is edited or deleted.
- Gives `StrengthTraining` an explicit `Date` field (migrated from `CreatedAt` for existing rows) instead of overloading `CreatedAt` as the training day, so retroactive logging and day plans work correctly.
- Replaces the old per-set bar charts on the Graph page (unreadable once more than a handful of sessions exist) with per-training-day aggregation: top set weight, estimated 1RM (Epley), and volume, plus a weekly volume/frequency overview.
- Adds a new Sessions page grouping sets into training days with plan linkage and completion rate.

## Why
Logging a workout previously meant submitting the strength training Create form once per set, with no way to plan a session ahead of time, reuse a previous plan, or see planned-vs-actual performance. The old Graph page rendered one bar per individual set over the entire history, which became unreadable after a few months of training.

## Notes for reviewers
- New EF Core migration `20260809090921_TrainingPlans`: adds `Date`/`TrainingPlanId`/`TrainingPlanSetId` to `StrengthTrainings`, backfills `Date = CreatedAt` via raw SQL (same pattern as the existing `JournalDate` migration), and creates the `TrainingPlans`/`TrainingPlanSets` tables. Verified against a copy of a real seeded database: all existing rows backfilled correctly, other tables untouched, and deleting a plan with logged trainings correctly clears the FK instead of cascading.
- `TrainingPlansService` overrides `BaseCRUDService` to `.Include()` the `Sets` child collection (the generic repository stack does no eager loading) and implements full-replace semantics on `Update`, matching the existing MCP tool conventions.
- The plan's exercise-name autocomplete uses a plain `<datalist>` instead of Tagify, since Tagify would need per-row re-initialization after each clone from the row `<template>`.
- Manually verified in-browser: plan creation with the dynamic set editor, template → dated copy → workout capture → reload-resume → undo, plan deletion preserving logged history, the new Graph/Sessions pages, and the REST API (copy, full list with nested sets, delete).
- Adds `.claude/launch.json` for local dev-server preview (not previously in the repo).

## Test plan
- [x] `dotnet build` succeeds
- [x] Migration applied to a copy of a real database; `Date` backfilled, no data loss
- [x] UI walkthrough: create plan → copy → start workout → confirm/undo sets → reload mid-workout → plan Details (Soll/Ist) → delete plan → training history preserved
- [x] Graph and Sessions pages render without console/network errors
- [x] REST API: `GET/POST/DELETE /api/trainingplans`, copy endpoint, nested sets round-trip correctly
- [ ] MCP tools not exercised live in this session (require the configured MCP token/JWT flow) — code follows the same pattern as the existing `StrengthTrainingsTool`

🤖 Generated with [Claude Code](https://claude.com/claude-code)